### PR TITLE
Fix mobile sizing for card container

### DIFF
--- a/src/Folder.jsx
+++ b/src/Folder.jsx
@@ -53,15 +53,12 @@ export default function Stack({
     setExpanded(true);
   };
 
-  // Ajustar el contenedor para usar porcentajes
-  const containerWidth = "100%";
+
 
   return (
     <div
       className="relative flex items-center justify-center select-none mx-auto card-stack-container"
       style={{
-        width: window.innerWidth < 768 ? "100%" : "100%",
-        height: window.innerWidth < 768 ? "350px" : "400px",
         perspective: 600,
         maxWidth: "600px", // Aumentamos el ancho máximo
         marginBottom: "40px",


### PR DESCRIPTION
## Summary
- keep width/height CSS rules for `.card-stack-container`
- stop overriding responsive width/height in `Folder.jsx`

## Testing
- `npm run build` *(fails: esbuild binary for win32 present)*

------
https://chatgpt.com/codex/tasks/task_e_6887db506cec8329941b9e7729b8e53f