### PR TITLE
Fix starry background visibility

### DIFF
--- a/src/DotGrid.jsx
+++ b/src/DotGrid.jsx
@@ -301,7 +301,7 @@ const DotGrid = ({
       style={{
         ...style,
         position: 'relative',
-        backgroundColor: '#000000',
+        backgroundColor: 'transparent',
         backgroundSize: 'cover',
         backgroundPosition: 'center'
       }}


### PR DESCRIPTION
## Summary
- allow the starry background to be visible by making DotGrid transparent

## Testing
- `npm run dev` *(fails: couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_6887dcae7c7c8329bd66434f6a488049