### PR TITLE
Update hero copy and scheduling prompt

### DIFF
--- a/src/ContactForm.jsx
+++ b/src/ContactForm.jsx
@@ -491,12 +491,17 @@ export default function ContactForm() {
                       <option value="no">No por ahora</option>
                     </select>
                     {form.contacto.llamada === 'si' && (
-                      <input type="text" className="mt-2 w-full rounded px-3 py-2 bg-[#202020] text-[var(--color-accent)] border border-[var(--color-accent)]" value={form.contacto.horario} onChange={e => handleContacto('horario', e.target.value)} placeholder="Proporciona un horario o disponibilidad" />
+                      <>
+                        <div className="text-sm text-[#E0E0E0] mt-2">{t('contact.schedulePrompt')}</div>
+                        <input type="text" className="mt-1 w-full rounded px-3 py-2 bg-[#202020] text-[var(--color-accent)] border border-[var(--color-accent)]" value={form.contacto.horario} onChange={e => handleContacto('horario', e.target.value)} placeholder={t('contact.schedulePrompt')} />
+                      </>
                     )}
                   </div>
                   <div className="form-btn-container">
                     <button type="button" className="form-btn-back" onClick={handleBack}>Atrás</button>
-                    <button type="submit" className="form-btn-next">Enviar</button>
+                    <button type="submit" className="form-btn-next">
+                      {form.contacto.llamada === 'si' ? t('contact.scheduleButton') : t('contact.submitButton')}
+                    </button>
                   </div>
                 </div>
               )}

--- a/src/StarryBackground.jsx
+++ b/src/StarryBackground.jsx
@@ -88,7 +88,6 @@ const StarryBackground = ({ opacity = 1 }) => {
         if (star.y < 0) star.y += height;
         if (star.y > height) star.y -= height;
       }
-      2ljzzw-codex/adjust-mobile-and-desktop-moon-illustration
       ctx.strokeStyle = `rgba(255, 255, 255, ${0.35 * opacity})`;
       ctx.lineWidth = 1;
       for (const constellation of constellations) {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -11,7 +11,7 @@
     "english": "Español"
   },
   "hero": {
-    "title": "Take your company to space and beyond",
+    "title": "Boost your business with web solutions orbiting innovation and security.",
     "subtitle": "Your business deserves a stellar online presence. We'll help you reach for the stars.",
     "motivational": "The universe of digital possibilities awaits your brand",
     "cta": "Discover how"
@@ -73,7 +73,9 @@
     "emailRequired": "Please enter a valid email",
     "messageRequired": "Please tell us about your project",
     "success": "Message sent successfully! We will contact you soon.",
-    "error": "There was an error sending your message. Please try again later."
+    "error": "There was an error sending your message. Please try again later.",
+    "schedulePrompt": "Choose your preferred time slot and let's launch your project today.",
+    "scheduleButton": "Schedule call"
   },
   "folder": {
     "clickToCollapse": "Click to collapse",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -11,7 +11,7 @@
     "english": "English"
   },
   "hero": {
-    "title": "Lleva tu empresa al espacio y más allá",
+    "title": "Impulsa tu empresa con soluciones web orbitadas en innovación y seguridad.",
     "subtitle": "Tu negocio merece una presencia estelar en línea. Te ayudaremos a alcanzar las estrellas.",
     "motivational": "El universo de posibilidades digitales espera a tu marca",
     "cta": "Descubre cómo"
@@ -74,6 +74,8 @@
     "messageRequired": "Por favor cuéntanos sobre tu proyecto",
     "success": "¡Mensaje enviado con éxito! Nos pondremos en contacto pronto.",
     "error": "Hubo un error al enviar tu mensaje. Por favor intenta más tarde.",
+    "schedulePrompt": "Elige tu franja horaria y despeguemos tu proyecto hoy mismo.",
+    "scheduleButton": "Agendar llamada",
     "services": {
       "web": "Diseño o rediseño de sitio web",
       "dashboard": "Dashboard de analítica de negocio",


### PR DESCRIPTION
## Summary
- tweak hero title translations for a more modern tagline
- add schedule prompt and button text to translations
- enhance contact form scheduling UX
- remove stray text from `StarryBackground`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68893e49d3ec8329a95802d17d3679be