### PR TITLE
feat: adjust buttons and stats styling

### DIFF
--- a/src/StatsSection.jsx
+++ b/src/StatsSection.jsx
@@ -35,7 +35,7 @@ export default function StatsSection() {
       <div className="stats-container grid grid-cols-1 md:grid-cols-2 gap-8 w-full max-w-4xl">
         <div className="stat-item stat-animate gradient-border rounded-3xl">
           <div className="flex flex-col items-center p-8 rounded-3xl bg-black">
-            <span className="number text-white font-bold text-6xl md:text-8xl mb-4 number-glow">
+            <span className="number font-bold text-7xl md:text-9xl mb-4 number-glow inline-block">
               {t('whyus.stat1.number', '20 %')}
             </span>
             <p className="text-gray-300 text-center text-lg">
@@ -45,7 +45,7 @@ export default function StatsSection() {
         </div>
         <div className="stat-item stat-animate gradient-border rounded-3xl">
           <div className="flex flex-col items-center p-8 rounded-3xl bg-black">
-            <span className="number text-white font-bold text-6xl md:text-8xl mb-4 number-glow">
+            <span className="number font-bold text-7xl md:text-9xl mb-4 number-glow inline-block">
               {t('whyus.stat2.number', '42 %')}
             </span>
             <p className="text-gray-300 text-center text-lg">

--- a/src/index.css
+++ b/src/index.css
@@ -76,17 +76,17 @@ html, body {
 
 /* Clases para botones y elementos interactivos */
 .btn-primary {
-  background: linear-gradient(90deg, var(--color-accent), var(--color-highlight));
+  background: transparent;
   color: var(--color-text);
-  border: none;
+  border: 5px solid var(--color-accent);
   border-radius: 50px;
   padding: 14px 28px;
-  transition: background 0.4s ease, transform 0.3s ease, box-shadow 0.3s ease;
+  transition: border-color 0.4s ease, transform 0.3s ease, box-shadow 0.3s ease;
   box-shadow: 0 4px 8px rgba(111, 71, 255, 0.3);
 }
 
 .btn-primary:hover {
-  background: linear-gradient(90deg, var(--color-highlight), var(--color-accent));
+  border-color: var(--color-highlight);
   transform: translateY(-2px);
   box-shadow: 0 6px 12px rgba(255, 209, 0, 0.4);
 }
@@ -95,13 +95,14 @@ html, body {
 .btn-rounded {
   border-radius: 9999px; /* Completamente redondeados */
   padding: 16px 32px;
-  background: linear-gradient(90deg, var(--color-accent), var(--color-highlight));
+  background: transparent;
   color: var(--color-text);
-  transition: background 0.4s ease, transform 0.3s ease, box-shadow 0.3s ease;
+  border: 5px solid var(--color-accent);
+  transition: border-color 0.4s ease, transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .btn-rounded:hover {
-  background: linear-gradient(90deg, var(--color-highlight), var(--color-accent));
+  border-color: var(--color-highlight);
   transform: translateY(-2px);
   box-shadow: 0 6px 12px rgba(255, 209, 0, 0.4);
 }
@@ -384,13 +385,21 @@ html, body {
   opacity: 1 !important;
   transform: none !important;
 }
+.number {
+  background: linear-gradient(90deg, var(--color-accent), var(--color-highlight), #8b00ff);
+  -webkit-background-clip: text;
+  color: transparent;
+  border: 1px solid var(--color-accent);
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.5rem;
+}
 .number-glow {
   text-shadow: 0 0 15px rgba(111, 71, 255, 1);
   animation: pulse-glow 2s ease-in-out infinite alternate;
 }
 
 .gradient-border {
-  background: linear-gradient(to bottom right, #6b21a8, #6f47ff, #000);
+  background: linear-gradient(to bottom right, #6b21a8, #6f47ff, #8b00ff);
   padding: 2px;
 }
 @keyframes pulse-glow {


### PR DESCRIPTION
## Summary
- make rounded and primary buttons transparent with a 5px accent border
- enlarge stat numbers with gradient text and simple border
- enrich gradient borders with deeper purple tone

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e51482690832989fce41df50c38be