### PR TITLE
feat: adjust buttons and stats styling

### DIFF
--- a/src/FluidGlass.jsx
+++ b/src/FluidGlass.jsx
@@ -218,7 +218,7 @@ function NavItems({ items }) {
   useFrame(() => {
     if (!group.current) return
     const v = viewport.getCurrentViewport(camera, [0, 0, 15])
-    group.current.position.set(0, -v.height / 2 + 0.2, 15.1)
+    group.current.position.set(0, -v.height / 2 + 0.05, 15.1)
 
     group.current.children.forEach((child, i) => {
       child.position.x = (i - (items.length - 1) / 2) * spacing

--- a/src/StatsSection.jsx
+++ b/src/StatsSection.jsx
@@ -35,7 +35,7 @@ export default function StatsSection() {
       <div className="stats-container grid grid-cols-1 md:grid-cols-2 gap-8 w-full max-w-4xl">
         <div className="stat-item stat-animate gradient-border rounded-3xl">
           <div className="flex flex-col items-center p-8 rounded-3xl bg-black">
-            <span className="number text-white font-bold text-6xl md:text-8xl mb-4 number-glow">
+            <span className="number font-bold text-7xl md:text-9xl mb-4 inline-block">
               {t('whyus.stat1.number', '20 %')}
             </span>
             <p className="text-gray-300 text-center text-lg">
@@ -45,7 +45,7 @@ export default function StatsSection() {
         </div>
         <div className="stat-item stat-animate gradient-border rounded-3xl">
           <div className="flex flex-col items-center p-8 rounded-3xl bg-black">
-            <span className="number text-white font-bold text-6xl md:text-8xl mb-4 number-glow">
+            <span className="number font-bold text-7xl md:text-9xl mb-4 inline-block">
               {t('whyus.stat2.number', '42 %')}
             </span>
             <p className="text-gray-300 text-center text-lg">

--- a/src/index.css
+++ b/src/index.css
@@ -30,8 +30,8 @@ head::before {
   --color-dark-bg: #0C0D13;     /* Shale (Background) - Fondo principal */
   --color-slate: #1E1F26;       /* Dark Slate (Surfaces) - Tarjetas, nav */
   --color-gunmetal: #2A2C37;    /* Gunmetal (Detalles) - Bordes, divisores */
-  --color-accent: #6F47FF;      /* Tech Purple (Accent) - Botones CTA */
-  --color-highlight: #A66AFF;   /* Brillo (Highlight) */
+  --color-accent: #D946EF;      /* Tech Purple (Accent) - Botones CTA */
+  --color-highlight: #FF00FF;   /* Brillo (Highlight) */
   --color-text: #ECECEC;        /* Soft White (Texto) - Texto principal */
 }
 
@@ -76,34 +76,36 @@ html, body {
 
 /* Clases para botones y elementos interactivos */
 .btn-primary {
-  background: linear-gradient(90deg, var(--color-accent), var(--color-highlight));
+  background: transparent;
   color: var(--color-text);
-  border: none;
+  border: 2px solid var(--color-accent);
   border-radius: 50px;
   padding: 14px 28px;
-  transition: background 0.4s ease, transform 0.3s ease, box-shadow 0.3s ease;
-  box-shadow: 0 4px 8px rgba(111, 71, 255, 0.3);
+  transition: border-color 0.4s ease, transform 0.3s ease, box-shadow 0.3s ease;
+  box-shadow: 0 2px 6px rgba(217, 70, 239, 0.3);
 }
 
 .btn-primary:hover {
-  background: linear-gradient(90deg, var(--color-highlight), var(--color-accent));
+  border-color: var(--color-highlight);
   transform: translateY(-2px);
-  box-shadow: 0 6px 12px rgba(255, 209, 0, 0.4);
+  box-shadow: 0 4px 8px rgba(255, 0, 255, 0.4);
 }
 
 /* Clase específica para botones con bordes más redondeados */
 .btn-rounded {
   border-radius: 9999px; /* Completamente redondeados */
   padding: 16px 32px;
-  background: linear-gradient(90deg, var(--color-accent), var(--color-highlight));
+  background: transparent;
   color: var(--color-text);
-  transition: background 0.4s ease, transform 0.3s ease, box-shadow 0.3s ease;
+  border: 2px solid var(--color-accent);
+  transition: border-color 0.4s ease, transform 0.3s ease, box-shadow 0.3s ease;
+  box-shadow: 0 2px 6px rgba(217, 70, 239, 0.3);
 }
 
 .btn-rounded:hover {
-  background: linear-gradient(90deg, var(--color-highlight), var(--color-accent));
+  border-color: var(--color-highlight);
   transform: translateY(-2px);
-  box-shadow: 0 6px 12px rgba(255, 209, 0, 0.4);
+  box-shadow: 0 4px 8px rgba(255, 0, 255, 0.4);
 }
 
 /* Botones de formulario para navegación */
@@ -384,22 +386,15 @@ html, body {
   opacity: 1 !important;
   transform: none !important;
 }
-.number-glow {
-  text-shadow: 0 0 15px rgba(111, 71, 255, 1);
-  animation: pulse-glow 2s ease-in-out infinite alternate;
+.number {
+  background: linear-gradient(90deg, #ff00ff, var(--color-accent), #9f00ff);
+  -webkit-background-clip: text;
+  color: transparent;
 }
 
 .gradient-border {
-  background: linear-gradient(to bottom right, #6b21a8, #6f47ff, #000);
-  padding: 2px;
-}
-@keyframes pulse-glow {
-  from {
-    text-shadow: 0 0 10px rgba(111, 71, 255, 0.8);
-  }
-  to {
-    text-shadow: 0 0 20px rgba(111, 71, 255, 1);
-  }
+  background: linear-gradient(to bottom right, #ff00ff, var(--color-accent), #9f00ff);
+  padding: 1px;
 }
 
 @tailwind base;


### PR DESCRIPTION
## Summary
- bring navbar slightly lower to separate it from main text
- use brighter accent colors with slim 2px borders on buttons and stat cards
- remove glow and surrounding boxes from stat numbers, keeping only gradient text

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e51482690832989fce41df50c38be