### PR TITLE
refactor: purple gradient stats numbers

### DIFF
--- a/src/StatsSection.jsx
+++ b/src/StatsSection.jsx
@@ -35,7 +35,7 @@ export default function StatsSection() {
       <div className="stats-container grid grid-cols-1 md:grid-cols-2 gap-8 w-full max-w-4xl">
         <div className="stat-item stat-animate gradient-border rounded-3xl">
           <div className="flex flex-col items-center p-8 rounded-3xl bg-black">
-            <span className="number font-bold text-7xl md:text-9xl mb-4 number-glow inline-block">
+            <span className="number font-bold text-7xl md:text-9xl mb-4 inline-block">
               {t('whyus.stat1.number', '20 %')}
             </span>
             <p className="text-gray-300 text-center text-lg">
@@ -45,7 +45,7 @@ export default function StatsSection() {
         </div>
         <div className="stat-item stat-animate gradient-border rounded-3xl">
           <div className="flex flex-col items-center p-8 rounded-3xl bg-black">
-            <span className="number font-bold text-7xl md:text-9xl mb-4 number-glow inline-block">
+            <span className="number font-bold text-7xl md:text-9xl mb-4 inline-block">
               {t('whyus.stat2.number', '42 %')}
             </span>
             <p className="text-gray-300 text-center text-lg">

--- a/src/index.css
+++ b/src/index.css
@@ -394,16 +394,11 @@ html, body {
   transform: none !important;
 }
 .number {
-  background: linear-gradient(90deg, var(--color-accent), #7f00ff);
+  background: linear-gradient(to right, #6b21a8, #6f47ff, #8b00ff);
   -webkit-background-clip: text;
   color: transparent;
   text-shadow: none;
   box-shadow: none;
-}
-
-.number-glow {
-  text-shadow: 0 0 15px rgba(111, 71, 255, 1);
-  animation: pulse-glow 2s ease-in-out infinite alternate;
 }
 
 .gradient-border {


### PR DESCRIPTION
## Summary
- remove glow shadow from stats numbers
- render stats numbers with a multi-stop purple gradient

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689117473d788329ae5e095a692ff87e