### PR TITLE
Fix asset paths for fonts and model

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <!-- Preload Ars Nova font files -->
     <link
       rel="preload"
-      href="/weavion/fonts/ArsNova-Regular.woff2"
+      href="/fonts/ArsNova-Regular.woff2"
       as="font"
       type="font/woff2"
       crossorigin
@@ -24,7 +24,7 @@
 
     <link
       rel="preload"
-      href="/weavion/fonts/ArsNova-Bold.woff2"
+      href="/fonts/ArsNova-Bold.woff2"
       as="font"
       type="font/woff2"
       crossorigin

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -211,12 +211,17 @@ function CursorStars() {
   );
 }
 
-function Landing() {
-  const { t } = useTranslation();
+  function Landing() {
+    const { t } = useTranslation();
 
   // Modelo GLB que reacciona al cursor
+  const MODEL_URL = new URL(
+    'models/phone_with_leads_optimized.glb',
+    import.meta.env.BASE_URL
+  ).href;
+
   function PhoneModel() {
-    const { scene } = useGLTF('/models/phone_with_leads_optimized.glb'); // pon el .glb en /public/models/
+    const { scene } = useGLTF(MODEL_URL); // pon el .glb en /public/models/
     const ref = useRef();
 
     useFrame((state) => {

--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,8 @@
 /* Importación de la fuente Ars Nova con mejora de carga y fallbacks */
 @font-face {
   font-family: 'Ars Nova';
-  src: url('/weavion/fonts/ArsNova-Regular.woff2') format('woff2'),
-       url('/weavion/fonts/ArsNova-Regular.woff') format('woff');
+  src: url('/fonts/ArsNova-Regular.woff2') format('woff2'),
+       url('/fonts/ArsNova-Regular.woff') format('woff');
   font-weight: normal;
   font-style: normal;
   font-display: swap;
@@ -11,8 +11,8 @@
 
 @font-face {
   font-family: 'Ars Nova';
-  src: url('/weavion/fonts/ArsNova-Bold.woff2') format('woff2'),
-       url('/weavion/fonts/ArsNova-Bold.woff') format('woff');
+  src: url('/fonts/ArsNova-Bold.woff2') format('woff2'),
+       url('/fonts/ArsNova-Bold.woff') format('woff');
   font-weight: bold;
   font-style: normal;
   font-display: swap;


### PR DESCRIPTION
## Summary
- load phone model using Vite base path to avoid 404s
- point font preloads and @font-face to generic `/fonts` path so Vite handles base

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897f970d0d08329961f2192cd7718a4