### PR TITLE
Fix model asset URL base usage

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -215,10 +215,7 @@ function CursorStars() {
     const { t } = useTranslation();
 
   // Modelo GLB que reacciona al cursor
-  const MODEL_URL = new URL(
-    'models/phone_with_leads_optimized.glb',
-    import.meta.env.BASE_URL
-  ).href;
+  const MODEL_URL = `${import.meta.env.BASE_URL}models/phone_with_leads_optimized.glb`;
 
   function PhoneModel() {
     const { scene } = useGLTF(MODEL_URL); // pon el .glb en /public/models/

--- a/src/HeroModel.jsx
+++ b/src/HeroModel.jsx
@@ -4,10 +4,7 @@ import { Canvas, useFrame } from '@react-three/fiber';
 import { Environment, useGLTF } from '@react-three/drei';
 
 // Ruta absoluta segura para Vite y GitHub Pages
-const MODEL_URL = new URL(
-  'models/phone_with_leads_optimized.glb',
-  import.meta.env.BASE_URL
-).href;
+const MODEL_URL = `${import.meta.env.BASE_URL}models/phone_with_leads_optimized.glb`;
 
 // Precarga del modelo
 useGLTF.preload(MODEL_URL);


### PR DESCRIPTION
## Summary
- avoid invalid URL construction by building model path from `import.meta.env.BASE_URL`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898024fc91c83299a4cbf8aff35f62d