### PR TITLE
Add service dropdowns to header navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -54,21 +54,38 @@ export default function App() {
 }
 
 function Header() {
-  const { i18n } = useTranslation();
+  const { t, i18n } = useTranslation();
   const toggleLang = () =>
     i18n.changeLanguage(i18n.language === 'es' ? 'en' : 'es');
 
+  const servicesItems = [
+    t('header.servicesItems.webDev', 'Diseño y Desarrollo web'),
+    t('header.servicesItems.crm', 'Integración a CRM o Service Titan'),
+    t('header.servicesItems.analytics', 'Analíticas de negocio'),
+  ];
+
+  const automationItems = [
+    t('header.automationItems.leads', 'Gestiona tus leads'),
+    t('header.automationItems.clients', 'Encuentra más clientes en diferentes plataformas'),
+  ];
+
   return (
-    <div className="fixed top-8 inset-x-0 z-50 flex items-center justify-between px-8">
+    <div className="fixed top-8 inset-x-0 z-50 flex items-center px-8">
       {/* Logo izquierda */}
-      <Link to="/">
+      <Link to="/" className="mr-8">
         <img src={logo} alt="Logo" className="w-14 h-14 object-contain" />
       </Link>
+
+      {/* Menús intermedios */}
+      <div className="flex-1 flex items-center justify-center space-x-8">
+        <DropdownMenu title={t('header.services', 'Servicios')} items={servicesItems} />
+        <DropdownMenu title={t('header.automation', 'Automatiza tu operación')} items={automationItems} />
+      </div>
 
       {/* Selector idioma con borde degradado */}
       <button
         onClick={toggleLang}
-        className="transition group flex h-10 w-20 items-center justify-center rounded-full 
+        className="transition group flex h-10 w-20 items-center justify-center rounded-full
                    bg-gradient-to-r from-purple-500 via-pink-500 to-purple-500 p-[2px] text-white
                    duration-300 hover:bg-gradient-to-l hover:shadow-2xl hover:shadow-purple-600/30"
       >
@@ -76,6 +93,23 @@ function Header() {
           {i18n.language === 'es' ? 'EN' : 'ES'}
         </div>
       </button>
+    </div>
+  );
+}
+
+function DropdownMenu({ title, items }) {
+  return (
+    <div className="relative group">
+      <div className="cursor-pointer text-white px-2 py-1 rounded-md">
+        {title}
+      </div>
+      <div className="absolute left-1/2 -translate-x-1/2 mt-2 hidden flex-col rounded-md bg-black/80 text-white shadow-lg group-hover:flex">
+        {items.map((item, idx) => (
+          <div key={idx} className="px-4 py-2 whitespace-nowrap hover:bg-purple-700/20">
+            {item}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -10,6 +10,19 @@
     "contact": "Contact",
     "english": "Español"
   },
+  "header": {
+    "services": "Services",
+    "servicesItems": {
+      "webDev": "Web Design & Development",
+      "crm": "CRM or Service Titan integration",
+      "analytics": "Business analytics"
+    },
+    "automation": "Automate your operations",
+    "automationItems": {
+      "leads": "Manage your leads",
+      "clients": "Find more clients across platforms"
+    }
+  },
   "hero": {
     "title": "Boost your business with web solutions orbiting innovation and security.",
     "subtitle": "Your business deserves a stellar online presence. We'll help you reach for the stars.",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -10,6 +10,19 @@
     "contact": "Contacto",
     "english": "English"
   },
+  "header": {
+    "services": "Servicios",
+    "servicesItems": {
+      "webDev": "Diseño y Desarrollo web",
+      "crm": "Integración a CRM o Service Titan",
+      "analytics": "Analíticas de negocio"
+    },
+    "automation": "Automatiza tu operación",
+    "automationItems": {
+      "leads": "Gestiona tus leads",
+      "clients": "Encuentra más clientes en diferentes plataformas"
+    }
+  },
   "hero": {
     "title": "Impulsa tu empresa con soluciones web orbitadas en innovación y seguridad.",
     "subtitle": "Tu negocio merece una presencia estelar en línea. Te ayudaremos a alcanzar las estrellas.",


### PR DESCRIPTION
## Summary
- add service and automation dropdown menus between logo and language selector
- localize new menu text in Spanish and English

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68980a9299408329be9df48d97662877