### PR TITLE
Add horizontal services section after landing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ import StatsSection from './StatsSection';
 import ProcessTimeline from './ProcessTimeline';
 import ContactSection from './ContactSection';
 import logo from './assets/weavion.logo.png';
+import HorizontalSnapSections from './full_screen_services_section.jsx';
 
 export default function App() {
   return (
@@ -24,6 +25,8 @@ export default function App() {
       <CursorStars />
       <div className="relative z-10">
         <Landing />
+        {/* Services Section */}
+        <HorizontalSnapSections />
 
         {/* Spacer */}
         <div className="h-12 md:h-24" />


### PR DESCRIPTION
## Summary
- import horizontal snap sections component
- show full-screen horizontal services slider after landing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898d26f838c8329b7d6e6eedda6e3d1