### PR TITLE
Fix undefined loader and font paths

### DIFF
--- a/src/HeroModel.jsx
+++ b/src/HeroModel.jsx
@@ -49,8 +49,3 @@ export default function HeroModel() {
     </Canvas>
   );
 }
-
-loader.load(MODEL_URL, onLoad, undefined, (err) => {
-  console.error('Fallo cargando modelo', err);
-  // aquí puedes ocultar la escena o mostrar un placeholder
-});

--- a/src/index.css
+++ b/src/index.css
@@ -2,8 +2,8 @@
 /* src/index.css */
 @font-face {
   font-family: 'Ars Nova';
-  src: url('./assets/fonts/ArsNova-Regular.woff2') format('woff2'),
-       url('./assets/fonts/ArsNova-Regular.woff') format('woff');
+  src: url('/fonts/ArsNova-Regular.woff2') format('woff2'),
+       url('/fonts/ArsNova-Regular.woff') format('woff');
   font-weight: 400;
   font-style: normal;
   font-display: swap;
@@ -11,8 +11,8 @@
 
 @font-face {
   font-family: 'Ars Nova';
-  src: url('./assets/fonts/ArsNova-Bold.woff2') format('woff2'),
-       url('./assets/fonts/ArsNova-Bold.woff') format('woff');
+  src: url('/fonts/ArsNova-Bold.woff2') format('woff2'),
+       url('/fonts/ArsNova-Bold.woff') format('woff');
   font-weight: 700;
   font-style: normal;
   font-display: swap;


### PR DESCRIPTION
## Summary
- remove stray loader call in HeroModel that caused runtime error
- fix Ars Nova font URLs to load from public fonts directory

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898d6689fd08329ab15a652fbc6876e