### PR TITLE
Split automation pages into separate routes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -78,23 +78,23 @@ function Header() {
   const automationItems = [
     {
       label: t('header.automationItems.appointments', 'Genera citas'),
-      path: '/contact',
+      path: '/automation/genera-citas',
     },
     {
       label: t('header.automationItems.inventoryChat', 'Charla con tu inventario y modifícalo'),
-      path: '/contact',
+      path: '/automation/inventario-chat',
     },
     {
       label: t('header.automationItems.leads', 'Captura y califica tus leads'),
-      path: '/contact',
+      path: '/automation/captura-califica-leads',
     },
     {
       label: t('header.automationItems.quotes', 'Entrega cotizaciones inmediatas y ten una postventa inteligente'),
-      path: '/contact',
+      path: '/automation/cotizaciones-postventa',
     },
     {
       label: t('header.automationItems.contact', '¿Buscas algo más? Contáctanos'),
-      path: '/contact',
+      path: '/automation/contacto',
     },
   ];
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -7,6 +7,11 @@ import ContactPage from './ContactPage';
 import DisenoDesarrolloWeb from './pages/DisenoDesarrolloWeb';
 import IntegracionCRM from './pages/IntegracionCRM';
 import AnaliticasNegocio from './pages/AnaliticasNegocio';
+import GeneraCitas from './pages/Automatizaciones/GeneraCitas';
+import CapturaCalificaLeads from './pages/Automatizaciones/CapturaCalificaLeads';
+import InventarioChat from './pages/Automatizaciones/InventarioChat';
+import CotizacionesPostventa from './pages/Automatizaciones/CotizacionesPostventa';
+import ContactoMas from './pages/Automatizaciones/ContactoMas';
 import './index.css';
 import './i18n';
 
@@ -20,6 +25,11 @@ ReactDOM.createRoot(document.getElementById('root')).render(
         <Route path="services/crm"        element={<IntegracionCRM />} />
         <Route path="services/analiticas" element={<AnaliticasNegocio />} />
         <Route path="contact"    element={<ContactPage />} />
+        <Route path="automation/genera-citas" element={<GeneraCitas />} />
+        <Route path="automation/captura-califica-leads" element={<CapturaCalificaLeads />} />
+        <Route path="automation/inventario-chat" element={<InventarioChat />} />
+        <Route path="automation/cotizaciones-postventa" element={<CotizacionesPostventa />} />
+        <Route path="automation/contacto" element={<ContactoMas />} />
         <Route path="*"          element={<Landing />} />  {/* fallback a landing */}
       </Routes>
     </HashRouter>

--- a/src/pages/Automatizaciones/CapturaCalificaLeads.jsx
+++ b/src/pages/Automatizaciones/CapturaCalificaLeads.jsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { motion } from "framer-motion";
+import { GradientBg, CTAButton, PALETTE } from "./common";
+
+export default function CapturaCalificaLeads() {
+  const scores = [65, 72, 82, 91, 77, 88];
+  return (
+    <GradientBg>
+      <section className="mx-auto max-w-[1200px] px-6 py-20 md:py-28">
+        <header className="mb-12 md:mb-16">
+          <motion.h1
+            initial={{ y: 20, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            transition={{ duration: 0.6 }}
+            className="font-extrabold tracking-tight"
+            style={{
+              fontSize: "clamp(36px,7vw,84px)",
+              letterSpacing: "-0.02em",
+              backgroundImage: `linear-gradient(90deg, ${PALETTE.purpleBright}, #fff)`,
+              WebkitBackgroundClip: "text",
+              color: "transparent",
+            }}
+          >
+            Leads que valen la pena.
+          </motion.h1>
+          <p className="max-w-3xl" style={{ color: PALETTE.grayLight }}>
+            Enriquecimiento, deduplicación, filtros anti-spam y un score de
+            intención para priorizar al equipo.
+          </p>
+          <div className="mt-6">
+            <CTAButton>Empezar a calificar</CTAButton>
+          </div>
+        </header>
+
+        <div className="grid gap-6 md:grid-cols-3">
+          {["Enriquecimiento automático", "Score por comportamiento", "Ruteo según SLA"].map((t, i) => (
+            <motion.div
+              key={i}
+              initial={{ opacity: 0, y: 10 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.1 }}
+              className="rounded-3xl border bg-white/5 p-6 backdrop-blur-xl"
+              style={{
+                borderColor: "rgba(115,40,232,.35)",
+                color: PALETTE.grayLight,
+              }}
+            >
+              <div className="text-white">{t}</div>
+            </motion.div>
+          ))}
+        </div>
+
+        <div className="mt-10 grid gap-4 md:grid-cols-2">
+          {scores.map((s, i) => (
+            <div
+              key={i}
+              className="rounded-xl border bg-white/5 p-4"
+              style={{ borderColor: "rgba(115,40,232,.25)" }}
+            >
+              <div className="mb-1 text-xs" style={{ color: PALETTE.grayLight }}>
+                Lead #{i + 1}
+              </div>
+              <div className="h-2 w-full overflow-hidden rounded-full bg-black/40">
+                <motion.div
+                  initial={{ width: 0 }}
+                  whileInView={{ width: `${s}%` }}
+                  viewport={{ once: true }}
+                  transition={{ duration: 0.8 }}
+                  className="h-full"
+                  style={{ background: PALETTE.purpleBright }}
+                />
+              </div>
+              <div className="mt-1 text-sm text-white">Score {s}%</div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </GradientBg>
+  );
+}
+

--- a/src/pages/Automatizaciones/ContactoMas.jsx
+++ b/src/pages/Automatizaciones/ContactoMas.jsx
@@ -1,0 +1,160 @@
+import React, { useState } from "react";
+import { motion } from "framer-motion";
+import {
+  GradientBg,
+  PALETTE,
+  FormInput,
+  FormTextarea,
+  FormSelect,
+} from "./common";
+
+export default function ContactoMas() {
+  const SUBMIT_URL = "/api/contact";
+  const [status, setStatus] = useState("idle");
+  const [form, setForm] = useState({
+    nombre: "",
+    email: "",
+    empresa: "",
+    telefono: "",
+    servicio: "Otro",
+    presupuesto: "",
+    plazo: "",
+    mensaje: "",
+  });
+
+  const onChange = (e) =>
+    setForm((f) => ({ ...f, [e.target.name]: e.target.value }));
+
+  const onSubmit = async (e) => {
+    e.preventDefault();
+    if (!form.nombre || !form.email || !form.mensaje) {
+      setStatus("error");
+      return;
+    }
+    try {
+      setStatus("loading");
+      const res = await fetch(SUBMIT_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...form, source: "weavion-contacto" }),
+      });
+      if (!res.ok) throw new Error("bad status");
+      setStatus("success");
+      setForm({
+        nombre: "",
+        email: "",
+        empresa: "",
+        telefono: "",
+        servicio: "Otro",
+        presupuesto: "",
+        plazo: "",
+        mensaje: "",
+      });
+    } catch (err) {
+      setStatus("error");
+    }
+  };
+
+  return (
+    <GradientBg>
+      <section className="mx-auto max-w-[980px] px-6 py-20 md:py-28">
+        <header className="mb-10">
+          <motion.h1
+            initial={{ y: 20, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            transition={{ duration: 0.6 }}
+            className="font-extrabold tracking-tight"
+            style={{
+              fontSize: "clamp(36px,7vw,84px)",
+              letterSpacing: "-0.02em",
+              backgroundImage: `linear-gradient(90deg, ${PALETTE.purpleBright}, #fff)`,
+              WebkitBackgroundClip: "text",
+              color: "transparent",
+            }}
+          >
+            ¿Buscas algo más? Contáctanos.
+          </motion.h1>
+          <p style={{ color: PALETTE.grayLight }}>
+            Cuéntanos lo que necesitas y te proponemos un flujo ideal (web, CRM,
+            email, automatizaciones).
+          </p>
+        </header>
+
+        <form
+          onSubmit={onSubmit}
+          className="rounded-3xl border bg-white/5 p-6 backdrop-blur-xl"
+          style={{ borderColor: "rgba(115,40,232,.35)" }}
+        >
+          <div className="grid gap-4 md:grid-cols-2">
+            <FormInput label="Nombre" name="nombre" value={form.nombre} onChange={onChange} required />
+            <FormInput label="Email" name="email" type="email" value={form.email} onChange={onChange} required />
+            <FormInput label="Empresa" name="empresa" value={form.empresa} onChange={onChange} />
+            <FormInput label="Teléfono" name="telefono" value={form.telefono} onChange={onChange} />
+            <FormSelect
+              label="Servicio"
+              name="servicio"
+              value={form.servicio}
+              onChange={onChange}
+              options={[
+                "Automatizaciones",
+                "Diseño/Desarrollo Web",
+                "Integración CRM",
+                "Email Marketing",
+                "Analíticas",
+                "Otro",
+              ]}
+            />
+            <FormInput
+              label="Presupuesto (USD)"
+              name="presupuesto"
+              type="number"
+              value={form.presupuesto}
+              onChange={onChange}
+            />
+            <FormSelect
+              label="Plazo estimado"
+              name="plazo"
+              value={form.plazo}
+              onChange={onChange}
+              options={[
+                "Urgente (1-2 semanas)",
+                "Corto (1 mes)",
+                "Medio (2-3 meses)",
+                "Flexible",
+              ]}
+            />
+            <div className="md:col-span-2">
+              <FormTextarea
+                label="Mensaje"
+                name="mensaje"
+                value={form.mensaje}
+                onChange={onChange}
+                required
+              />
+            </div>
+          </div>
+          <div className="mt-5 flex items-center gap-3">
+            <button
+              disabled={status === "loading"}
+              className="rounded-full px-5 py-3 text-sm disabled:opacity-60"
+              style={{ border: `2px solid ${PALETTE.purpleBright}`, color: PALETTE.purpleBright }}
+            >
+              {status === "loading" ? "Enviando…" : "Enviar"}
+            </button>
+            {status === "success" && (
+              <span className="text-sm" style={{ color: PALETTE.grayLight }}>
+                ¡Gracias! Te contactaremos pronto.
+              </span>
+            )}
+            {status === "error" && (
+              <span className="text-sm text-red-300">
+                Revisa los campos obligatorios o intenta más tarde.
+              </span>
+            )}
+          </div>
+        </form>
+      </section>
+    </GradientBg>
+  );
+}
+

--- a/src/pages/Automatizaciones/CotizacionesPostventa.jsx
+++ b/src/pages/Automatizaciones/CotizacionesPostventa.jsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { motion } from "framer-motion";
+import { GradientBg, CTAButton, PALETTE } from "./common";
+
+export default function CotizacionesPostventa() {
+  return (
+    <GradientBg>
+      <section className="mx-auto max-w-[1200px] px-6 py-20 md:py-28">
+        <header className="mb-12 md:mb-16">
+          <motion.h1
+            initial={{ y: 20, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            transition={{ duration: 0.6 }}
+            className="font-extrabold tracking-tight"
+            style={{
+              fontSize: "clamp(36px,7vw,84px)",
+              letterSpacing: "-0.02em",
+              backgroundImage: `linear-gradient(90deg, ${PALETTE.purpleBright}, #fff)`,
+              WebkitBackgroundClip: "text",
+              color: "transparent",
+            }}
+          >
+            Cotiza en segundos. Mantén al cliente para siempre.
+          </motion.h1>
+          <p className="max-w-3xl" style={{ color: PALETTE.grayLight }}>
+            Configuradores, precios dinámicos, envío de propuestas con un clic y
+            postventa automatizada.
+          </p>
+          <div className="mt-6">
+            <CTAButton>Ver configurador</CTAButton>
+          </div>
+        </header>
+
+        <div className="grid gap-6 md:grid-cols-3">
+          {["Variantes y combos", "Aprobación por firma digital", "Encuestas post-servicio + NPS"].map((t, i) => (
+            <motion.div
+              key={i}
+              initial={{ opacity: 0, y: 10 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.1 }}
+              className="rounded-3xl border bg-white/5 p-6 backdrop-blur-xl"
+              style={{
+                borderColor: "rgba(115,40,232,.35)",
+                color: PALETTE.grayLight,
+              }}
+            >
+              <div className="text-white">{t}</div>
+            </motion.div>
+          ))}
+        </div>
+
+        <div
+          className="relative mt-12 rounded-3xl border bg-white/5 p-6 backdrop-blur-xl"
+          style={{ borderColor: "rgba(115,40,232,.35)" }}
+        >
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-4">
+            {["Configuración", "Precio", "Propuesta", "Seguimiento"].map(
+              (s, i) => (
+                <div
+                  key={i}
+                  className="rounded-2xl border bg-black/30 p-4 text-center"
+                  style={{
+                    borderColor: "rgba(172,172,172,.15)",
+                    color: "#fff",
+                  }}
+                >
+                  {s}
+                </div>
+              )
+            )}
+          </div>
+        </div>
+      </section>
+    </GradientBg>
+  );
+}
+

--- a/src/pages/Automatizaciones/GeneraCitas.jsx
+++ b/src/pages/Automatizaciones/GeneraCitas.jsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { motion } from "framer-motion";
+import { GradientBg, CTAButton, PALETTE } from "./common";
+
+export default function GeneraCitas() {
+  return (
+    <GradientBg>
+      <section className="mx-auto max-w-[1200px] px-6 py-20 md:py-28">
+        <header className="mb-12 md:mb-16">
+          <motion.h1
+            initial={{ y: 20, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            transition={{ duration: 0.6 }}
+            className="font-extrabold tracking-tight"
+            style={{
+              fontSize: "clamp(36px,7vw,84px)",
+              letterSpacing: "-0.02em",
+              backgroundImage: `linear-gradient(90deg, ${PALETTE.purpleBright}, #fff)`,
+              WebkitBackgroundClip: "text",
+              color: "transparent",
+            }}
+          >
+            Agenda más, con menos fricción.
+          </motion.h1>
+          <p className="max-w-3xl" style={{ color: PALETTE.grayLight }}>
+            Calendario sincronizado, confirmaciones por WhatsApp/SMS, recordatorios
+            inteligentes y reprogramación con un tap.
+          </p>
+          <div className="mt-6">
+            <CTAButton>Probar agenda inteligente</CTAButton>
+          </div>
+        </header>
+
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {[
+            {
+              t: "Reducción de no-shows",
+              d: "Recordatorios + confirmación doble vía WA/SMS/email.",
+            },
+            { t: "Slots dinámicos", d: "Disponibilidad real por técnico, zona y SLA." },
+            { t: "Embudo a cita", d: "Desde lead calificado → agendado en un flujo." },
+          ].map((c, i) => (
+            <motion.div
+              key={i}
+              initial={{ opacity: 0, y: 10 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.1 }}
+              className="rounded-3xl border bg-white/5 p-6 backdrop-blur-xl"
+              style={{
+                borderColor: "rgba(115,40,232,.35)",
+                color: PALETTE.grayLight,
+              }}
+            >
+              <div className="text-xl font-semibold text-white">{c.t}</div>
+              <div className="mt-1 text-sm">{c.d}</div>
+            </motion.div>
+          ))}
+        </div>
+
+        <div
+          className="relative mt-14 rounded-3xl border bg-white/5 p-6 backdrop-blur-xl"
+          style={{ borderColor: "rgba(115,40,232,.35)" }}
+        >
+          <h3 className="mb-3 text-sm" style={{ color: PALETTE.grayLight }}>
+            Flujo: lead → cita confirmada
+          </h3>
+          <svg width="100%" height="160" viewBox="0 0 1200 160" className="opacity-90">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <motion.circle
+                key={i}
+                cx={120 + i * 260}
+                cy={80}
+                r="18"
+                fill={PALETTE.purpleBright}
+                initial={{ scale: 0 }}
+                whileInView={{ scale: 1 }}
+                viewport={{ once: true }}
+                transition={{ delay: i * 0.15 }}
+              />
+            ))}
+            {Array.from({ length: 3 }).map((_, i) => (
+              <motion.path
+                key={i}
+                d={`M ${138 + i * 260} 80 H ${240 + i * 260}`}
+                stroke={PALETTE.purpleBright}
+                strokeWidth="3"
+                strokeLinecap="round"
+                initial={{ pathLength: 0 }}
+                whileInView={{ pathLength: 1 }}
+                viewport={{ once: true }}
+                transition={{ duration: 1.1, delay: i * 0.15 }}
+              />
+            ))}
+          </svg>
+          <div
+            className="grid grid-cols-4 gap-4 text-center text-xs"
+            style={{ color: PALETTE.grayLight }}
+          >
+            <div>Formulario</div>
+            <div>Validación</div>
+            <div>Agenda</div>
+            <div>Confirmación</div>
+          </div>
+        </div>
+      </section>
+    </GradientBg>
+  );
+}
+

--- a/src/pages/Automatizaciones/InventarioChat.jsx
+++ b/src/pages/Automatizaciones/InventarioChat.jsx
@@ -1,0 +1,94 @@
+import React from "react";
+import { motion } from "framer-motion";
+import { GradientBg, PALETTE } from "./common";
+
+export default function InventarioChat() {
+  const msgs = [
+    { from: "user", text: "¿Cuántas sillas negras quedan en Bogotá?" },
+    {
+      from: "bot",
+      text: "Stock: 34 unidades en bodega Salitre. ¿Reservar 5 para mañana?",
+    },
+    { from: "user", text: "Sí, y baja el precio en 5% por liquidación." },
+    {
+      from: "bot",
+      text:
+        "Listo. Nuevo precio aplicado y 5 unidades reservadas para retiro 10:00 AM.",
+    },
+  ];
+  return (
+    <GradientBg>
+      <section className="mx-auto max-w-[1000px] px-6 py-20 md:py-28">
+        <header className="mb-10">
+          <motion.h1
+            initial={{ y: 20, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            transition={{ duration: 0.6 }}
+            className="font-extrabold tracking-tight"
+            style={{
+              fontSize: "clamp(36px,7vw,84px)",
+              letterSpacing: "-0.02em",
+              backgroundImage: `linear-gradient(90deg, ${PALETTE.purpleBright}, #fff)`,
+              WebkitBackgroundClip: "text",
+              color: "transparent",
+            }}
+          >
+            Habla con tu inventario.
+          </motion.h1>
+          <p className="max-w-3xl" style={{ color: PALETTE.grayLight }}>
+            Consulta, reserva, ajusta precios y crea órdenes con lenguaje natural.
+          </p>
+        </header>
+
+        <div
+          className="rounded-3xl border bg-white/5 p-6 backdrop-blur-xl"
+          style={{ borderColor: "rgba(115,40,232,.35)" }}
+        >
+          <div className="space-y-3">
+            {msgs.map((m, i) => (
+              <div
+                key={i}
+                className={`${m.from === "user" ? "justify-end" : "justify-start"} flex`}
+              >
+                <div
+                  className={`max-w-[80%] rounded-2xl px-4 py-3 text-sm ${
+                    m.from === "user" ? "ml-auto" : "mr-auto"
+                  }`}
+                  style={{
+                    background:
+                      m.from === "user"
+                        ? "rgba(115,40,232,.25)"
+                        : "rgba(255,255,255,.06)",
+                    color: "#fff",
+                    border: "1px solid rgba(172,172,172,.15)",
+                  }}
+                >
+                  {m.text}
+                </div>
+              </div>
+            ))}
+          </div>
+          <div
+            className="mt-4 flex items-center gap-2 rounded-full border bg-black/30 p-2"
+            style={{ borderColor: "rgba(172,172,172,.2)" }}
+          >
+            <input
+              placeholder="Escribe un comando…"
+              className="flex-1 bg-transparent px-3 text-sm text-white placeholder-white/50 outline-none"
+            />
+            <button
+              className="rounded-full px-4 py-2 text-sm"
+              style={{
+                border: `2px solid ${PALETTE.purpleBright}`,
+                color: PALETTE.purpleBright,
+              }}
+            >
+              Enviar
+            </button>
+          </div>
+        </div>
+      </section>
+    </GradientBg>
+  );
+}
+

--- a/src/pages/Automatizaciones/common.jsx
+++ b/src/pages/Automatizaciones/common.jsx
@@ -1,0 +1,136 @@
+import React from "react";
+import { motion } from "framer-motion";
+import { ArrowRight } from "lucide-react";
+
+export const PALETTE = {
+  purpleDark: "#39166F",
+  purpleBright: "#7328E8",
+  blackPurple: "#170E26",
+  grayLight: "#ACACAC",
+  grayDark: "#565758",
+};
+
+export const GradientBg = ({ children }) => (
+  <div
+    className="min-h-screen w-full overflow-hidden text-white"
+    style={{
+      background: `radial-gradient(60% 80% at 20% 20%, rgba(255,255,255,.06), rgba(0,0,0,0) 60%), linear-gradient(120deg, ${PALETTE.blackPurple}, ${PALETTE.purpleDark})`,
+    }}
+  >
+    <div className="pointer-events-none absolute inset-0 -z-10">
+      <motion.div
+        initial={{ opacity: 0, scale: 0.85 }}
+        animate={{ opacity: 0.5, scale: [0.85, 1.05, 0.95] }}
+        transition={{ duration: 10, repeat: Infinity, ease: "easeInOut" }}
+        className="absolute -top-28 -left-28 h-72 w-72 rounded-full blur-3xl"
+        style={{
+          background:
+            "conic-gradient(from 90deg, #7328E8, rgba(115,40,232,.1), #39166F)",
+        }}
+      />
+      <motion.div
+        initial={{ opacity: 0, scale: 0.9 }}
+        animate={{ opacity: 0.35, scale: [1, 1.1, 0.95] }}
+        transition={{ duration: 12, repeat: Infinity, ease: "easeInOut" }}
+        className="absolute bottom-0 right-0 h-[22rem] w-[22rem] rounded-full blur-3xl"
+        style={{
+          background:
+            "radial-gradient(50% 50% at 50% 50%, #7328E8 0%, transparent 60%)",
+        }}
+      />
+    </div>
+    {children}
+  </div>
+);
+
+export const CTAButton = ({ children }) => (
+  <motion.button
+    whileHover={{ scale: 1.04 }}
+    whileTap={{ scale: 0.98 }}
+    className="group relative inline-flex items-center gap-2 rounded-full border-2 px-5 py-3 text-base"
+    style={{ borderColor: PALETTE.purpleBright, color: PALETTE.grayLight }}
+  >
+    <span
+      className="h-2 w-2 rounded-full"
+      style={{ background: PALETTE.purpleBright }}
+    />
+    {children}
+    <ArrowRight
+      className="transition-transform group-hover:translate-x-0.5"
+      size={18}
+    />
+  </motion.button>
+);
+
+export function FormInput({ label, name, value, onChange, type = "text", required }) {
+  return (
+    <label className="block text-sm">
+      <span
+        className="mb-1 inline-block"
+        style={{ color: PALETTE.grayLight }}
+      >
+        {label}
+        {required && <span className="text-red-300"> *</span>}
+      </span>
+      <input
+        name={name}
+        value={value}
+        onChange={onChange}
+        type={type}
+        className="w-full rounded-xl border bg-black/30 px-3 py-2 text-white outline-none focus:ring"
+        style={{ borderColor: "rgba(172,172,172,.2)" }}
+        required={required}
+      />
+    </label>
+  );
+}
+
+export function FormTextarea({ label, name, value, onChange, required }) {
+  return (
+    <label className="block text-sm">
+      <span
+        className="mb-1 inline-block"
+        style={{ color: PALETTE.grayLight }}
+      >
+        {label}
+        {required && <span className="text-red-300"> *</span>}
+      </span>
+      <textarea
+        name={name}
+        value={value}
+        onChange={onChange}
+        rows={5}
+        className="w-full resize-none rounded-xl border bg-black/30 px-3 py-2 text-white outline-none focus:ring"
+        style={{ borderColor: "rgba(172,172,172,.2)" }}
+        required={required}
+      />
+    </label>
+  );
+}
+
+export function FormSelect({ label, name, value, onChange, options = [] }) {
+  return (
+    <label className="block text-sm">
+      <span
+        className="mb-1 inline-block"
+        style={{ color: PALETTE.grayLight }}
+      >
+        {label}
+      </span>
+      <select
+        name={name}
+        value={value}
+        onChange={onChange}
+        className="w-full rounded-xl border bg-black/30 px-3 py-2 text-white outline-none focus:ring"
+        style={{ borderColor: "rgba(172,172,172,.2)" }}
+      >
+        {options.map((o) => (
+          <option key={o} value={o} className="bg-black">
+            {o}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+


### PR DESCRIPTION
## Summary
- divide single Automations component into standalone pages
- add router paths for each automation and link them in navbar dropdown

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68994114dc2883299ffd0177896bb400