### PR TITLE
Improve dropdown option card sizing and spacing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -132,12 +132,12 @@ function DropdownMenu({ title, items }) {
       <div className="cursor-pointer text-white px-4 py-2 rounded-md">
         {title}
       </div>
-      <div className="absolute left-1/2 -translate-x-1/2 mt-4 hidden group-hover:grid w-72 h-48 grid-cols-3 grid-rows-2 gap-2 p-4 text-white">
+      <div className="absolute left-1/2 -translate-x-1/2 mt-4 hidden group-hover:flex flex-col w-max space-y-2 p-4 text-white">
         {items.map(({ label, path }, idx) => (
           <Link
             key={idx}
             to={path}
-            className="gradient-border rounded-xl w-full h-full flex items-center justify-center text-center p-3 transition-shadow hover:shadow-[0_0_15px_rgba(111,71,255,0.7)]"
+            className="gradient-border rounded-2xl w-full px-4 py-3 text-center transition-shadow hover:shadow-[0_0_15px_rgba(111,71,255,0.7)]"
           >
             {label}
           </Link>


### PR DESCRIPTION
## Summary
- Refine dropdown menu items for Services and Automatiza tu operación so cards size to content
- Add consistent padding, spacing, and rounded borders for dropdown cards

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899644dc9b48329bbfe221a7ce64790