### PR TITLE
feat: secciones horizontales con efecto glass

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -146,12 +146,12 @@ function DropdownMenu({ title, items }) {
       <div className="cursor-pointer text-white px-4 py-2 rounded-md">
         {title}
       </div>
-      <div className="absolute left-1/2 -translate-x-1/2 mt-4 hidden group-hover:flex flex-col w-max space-y-2 p-4 text-white">
+      <div className="absolute left-1/2 -translate-x-1/2 mt-4 hidden group-hover:flex flex-row space-x-4 p-4 text-white">
         {items.map(({ label, path }, idx) => (
           <Link
             key={idx}
             to={path}
-            className="gradient-border rounded-2xl w-full px-4 py-3 text-center transition-shadow hover:shadow-[0_0_15px_rgba(111,71,255,0.7)]"
+            className="glass gradient-border rounded-2xl w-40 h-40 flex items-center justify-center text-center transition-shadow hover:shadow-[0_0_15px_rgba(111,71,255,0.7)]"
           >
             {label}
           </Link>


### PR DESCRIPTION
## Summary
- Mostrar los elementos de los menús "Servicios" y "Automatiza tu operación" como tarjetas horizontales
- Aplicar efecto glass, bordes redondeados y tamaño cuadrado a cada tarjeta del dropdown

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899e14840488329886b7c4a19b95dc1