### PR TITLE
fix: load 3D phone model correctly on landing

### DIFF
--- a/src/HeroModel.jsx
+++ b/src/HeroModel.jsx
@@ -3,8 +3,9 @@ import React, { useRef, Suspense } from 'react';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { Environment, useGLTF } from '@react-three/drei';
 
-// Ruta absoluta segura para Vite y GitHub Pages
-const MODEL_URL = `${import.meta.env.BASE_URL}models/phone_with_leads_optimized.glb`;
+// URL del modelo resuelta por Vite (soporta dev y producción)
+import modelUrl from '/models/phone_with_leads_optimized.glb?url';
+const MODEL_URL = modelUrl;
 
 // Precarga del modelo
 useGLTF.preload(MODEL_URL);


### PR DESCRIPTION
## Summary
- ensure the 3D phone model uses a Vite-resolved URL so it loads in dev and production

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899e1215354832998134e619081a426