### PR TITLE
Apply glass effect and starry background to contact section

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -50,7 +50,7 @@ export default function App() {
         <div className="h-12 md:h-24" />
 
         {/* Contact Section */}
-        <section className="py-24 px-4 bg-black rounded-xl overflow-hidden">
+        <section className="py-24 px-4 rounded-xl overflow-hidden bg-transparent">
           <ContactSection />
         </section>
 

--- a/src/ContactForm.jsx
+++ b/src/ContactForm.jsx
@@ -266,7 +266,7 @@ export default function ContactForm() {
       : 0;
 
   return (
-    <div className="contact-theme max-w-2xl mx-auto rounded-3xl p-6 md:p-10 shadow-2xl bg-[var(--color-slate)] backdrop-blur-sm">
+    <div className="contact-theme max-w-2xl mx-auto rounded-3xl p-6 md:p-10 shadow-2xl bg-white/10 backdrop-blur-md text-white">
       {/* Progress Bar */}
       <div className="w-full h-2 bg-[var(--color-gunmetal)] rounded-full mb-8">
         <div
@@ -284,7 +284,7 @@ export default function ContactForm() {
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
             >
-              <div className="subtitle text-[var(--color-accent)] text-center mb-4">
+              <div className="subtitle text-white text-center mb-4">
                 ¡Gracias por tu interés!
               </div>
               <div className="body-text text-white text-center">
@@ -332,7 +332,7 @@ export default function ContactForm() {
                     ))}
                   </div>
                   {errors.servicios && (
-                    <div className="text-[var(--color-accent)] mb-2">{errors.servicios}</div>
+                  <div className="text-white mb-2">{errors.servicios}</div>
                   )}
                   <button type="button" className="form-btn-next" onClick={handleNext}>
                     Siguiente
@@ -343,7 +343,7 @@ export default function ContactForm() {
               {/* Paso 2: Web */}
               {current === 'web' && (
                 <div>
-                  <div className="subtitle text-[var(--color-accent)] mb-4">
+                  <div className="subtitle text-white mb-4">
                     Sobre tu sitio web
                   </div>
 
@@ -481,7 +481,7 @@ export default function ContactForm() {
               {/* Paso: Dashboard */}
               {current === 'dashboard' && (
                 <div>
-                  <div className="subtitle text-[var(--color-accent)] mb-4">
+                  <div className="subtitle text-white mb-4">
                     Sobre tu dashboard de analítica
                   </div>
 
@@ -583,7 +583,7 @@ export default function ContactForm() {
               {/* Paso: ServiceTitan */}
               {current === 'servicetitan' && (
                 <div>
-                  <div className="subtitle text-[var(--color-accent)] mb-4">
+                  <div className="subtitle text-white mb-4">
                     Sobre integración con Service Titan
                   </div>
 
@@ -668,7 +668,7 @@ export default function ContactForm() {
               {/* Paso: Automatización */}
               {current === 'automatizacion' && (
                 <div>
-                  <div className="subtitle text-[var(--color-accent)] mb-4">
+                  <div className="subtitle text-white mb-4">
                     Sobre automatización de procesos
                   </div>
 
@@ -758,7 +758,7 @@ export default function ContactForm() {
               {/* Paso final: Contacto */}
               {current === 'contacto' && (
                 <div>
-                  <div className="subtitle text-[var(--color-accent)] mb-4">Datos de contacto</div>
+                  <div className="subtitle text-white mb-4">Datos de contacto</div>
 
                   <div className="mb-4">
                     <label className="block text-white mb-2">¿Cuál es tu nombre y empresa?</label>
@@ -771,7 +771,7 @@ export default function ContactForm() {
                       required
                     />
                     {errors.nombre && (
-                      <div className="text-[var(--color-accent)] mt-1">{errors.nombre}</div>
+                      <div className="text-white mt-1">{errors.nombre}</div>
                     )}
                   </div>
 
@@ -788,14 +788,14 @@ export default function ContactForm() {
                       required
                     />
                     {errors.email && (
-                      <div className="text-[var(--color-accent)] mt-1">{errors.email}</div>
+                      <div className="text-white mt-1">{errors.email}</div>
                     )}
                   </div>
 
                   <div className="mb-4">
                     <label className="block text-white mb-2">
                       ¿Cuál es tu presupuesto estimado para este proyecto?{' '}
-                      <span className="text-[var(--color-accent)]">(opcional)</span>
+                      <span className="text-white">(opcional)</span>
                     </label>
                     <input
                       type="text"

--- a/src/ContactPage.jsx
+++ b/src/ContactPage.jsx
@@ -2,20 +2,26 @@ import React from 'react';
 import ContactForm from './ContactForm';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
+import StarryBackground from './StarryBackground';
 
 export default function ContactPage() {
   const { t } = useTranslation();
   
   return (
-    <div className="min-h-screen bg-[var(--color-dark-bg)] flex flex-col items-center justify-center px-4 py-4">
-      <div className="w-full max-w-4xl mx-auto">
-        <ContactForm />
+    <>
+      <div className="fixed inset-0 z-0 bg-black">
+        <StarryBackground />
       </div>
-      <div className="mt-8 text-center">
-        <Link to="/" className="text-[var(--color-accent)] hover:underline font-semibold transition-colors">
-          {t('common.backHome') || 'Volver al inicio'}
-        </Link>
+      <div className="relative z-10 min-h-screen flex flex-col items-center justify-center px-4 py-4 text-white">
+        <div className="w-full max-w-4xl mx-auto">
+          <ContactForm />
+        </div>
+        <div className="mt-8 text-center">
+          <Link to="/" className="hover:underline font-semibold transition-colors">
+            {t('common.backHome') || 'Volver al inicio'}
+          </Link>
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/ContactSection.jsx
+++ b/src/ContactSection.jsx
@@ -5,22 +5,22 @@ import ActionButton from './ActionButton';
 
 export default function ContactSection() {
   const { t } = useTranslation();
-  
+
   return (
-    <section className="py-20 px-4 md:px-8 bg-[var(--color-dark-bg)] pb-32" id="contactSection">
-      <div className="max-w-5xl mx-auto text-center container-rounded bg-[var(--color-slate)] p-6 md:p-10 shadow-xl">
-        <h2 className="headline text-[var(--color-text)] mb-6">
+    <section className="py-20 px-4 md:px-8 pb-32 bg-transparent" id="contactSection">
+      <div className="max-w-5xl mx-auto text-center container-rounded bg-white/10 backdrop-blur-md p-6 md:p-10 shadow-xl text-white">
+        <h2 className="headline text-white mb-6">
           {t('contact.cta.title') || '¿Listo para dar el siguiente paso?'}
         </h2>
-        <p className="subtitle text-[var(--color-accent)] mb-8">
+        <p className="subtitle text-white mb-8">
           {t('contact.cta.subtitle') || 'Impulsa tu agencia hoy'}
         </p>
-        <p className="body-text text-[var(--color-text)] mb-12 max-w-3xl mx-auto">
+        <p className="body-text text-white mb-12 max-w-3xl mx-auto">
           {t('contact.cta.description') || 'Contáctanos hoy para comenzar a trabajar en tu proyecto. Nuestro equipo está listo para ayudarte a alcanzar tus objetivos.'}
         </p>
         <Link
           to="/contact"
-          className="inline-block btn-rounded text-2xl font-bold button-text hover:transform hover:scale-105 transition-all duration-300 shadow-lg"
+          className="inline-block btn-rounded text-2xl font-bold text-white hover:transform hover:scale-105 transition-all duration-300 shadow-lg"
         >
           {t('contact.cta.button') || 'Contáctanos'}
         </Link>


### PR DESCRIPTION
## Summary
- Restyle contact call-to-action with white text and glassy backdrop
- Show starry background behind contact section and contact page
- Ensure contact form uses consistent white text styling

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899e16390fc8329819e5fc9342fd9f0