### PR TITLE
Aplicar fuente pixel a títulos y mejorar selectores

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -158,20 +158,22 @@ function DropdownMenu({ title, items }) {
     <div ref={menuRef} className="relative mx-4">
       <button
         onClick={() => setOpen((o) => !o)}
-        className="cursor-pointer text-white px-4 py-2 rounded-md"
+        className="cursor-pointer text-white px-4 py-2 rounded-md font-argent"
       >
         {title}
       </button>
       {open && (
-        <div className="absolute left-1/2 -translate-x-1/2 mt-4 glass rounded-2xl flex flex-row space-x-4 p-4 text-white">
+        <div className="absolute left-1/2 -translate-x-1/2 mt-4 glass rounded-2xl grid grid-rows-2 grid-flow-col gap-4 p-4 text-white">
           {items.map(({ label, path }, idx) => (
             <Link
               key={idx}
               to={path}
               onClick={() => setOpen(false)}
-              className="gradient-border rounded-2xl w-40 h-40 flex items-center justify-center text-center transition-shadow hover:shadow-[0_0_15px_rgba(111,71,255,0.7)]"
+              className="group w-40 h-40 rounded-2xl p-[2px] bg-gradient-to-r from-purple-400 to-purple-700 text-white transition duration-300 hover:bg-gradient-to-l hover:shadow-2xl hover:shadow-purple-600/30"
             >
-              {label}
+              <div className="flex h-full w-full items-center justify-center rounded-2xl bg-black text-center transition duration-300 ease-in-out group-hover:bg-gradient-to-br group-hover:from-gray-700 group-hover:to-gray-900 font-argent">
+                {label}
+              </div>
             </Link>
           ))}
         </div>
@@ -303,16 +305,16 @@ function Landing() {
           <div className="absolute inset-0 bg-gradient-to-b from-black/50 via-transparent to-black/60 pointer-events-none" />
 
           <div className="relative z-10 grid grid-cols-1 md:grid-cols-2 items-center min-h-screen gap-8">
-            {/* IZQUIERDA: base sans-serif (font-clean) y frase en Argent Pixel CF (font-argent) */}
+            {/* IZQUIERDA: titulares en Argent Pixel CF */}
             <div className="md:pr-10 w-full md:w-[50vw] max-w-3xl text-left">
               <motion.h1
                 initial={{ opacity: 0, y: 60 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.8 }}
-                className="font-clean text-5xl md:text-7xl text-[#D6D6D6] mb-6 leading-tight"
+                className="font-argent text-5xl md:text-7xl text-[#D6D6D6] mb-6 leading-tight"
               >
                 Aumenta tu{' '}
-                <span className="font-argent text-white">presencia digital</span>, sin trabajar de más
+                <span className="font-argent-italic text-white">presencia digital</span>, sin trabajar de más
               </motion.h1>
 
               {/* Botón: solo borde degradado + punto negro; texto del botón en Argent Pixel CF */}

--- a/src/ServiciosPinnedSlider.jsx
+++ b/src/ServiciosPinnedSlider.jsx
@@ -120,8 +120,8 @@ function Panel({ item, thin, palette }) {
         <div style={{ position: "absolute", inset: 0, background: `linear-gradient(180deg, rgba(115,40,232,.7), rgba(115,40,232,.2))`, opacity: 0.25, pointerEvents: "none" }} />
       )}
       <div style={{ maxWidth: 920, opacity: thin ? 0.0 : 1.0, transition: "opacity .15s linear", color: palette.grayLight, textAlign: "left" }}>
-        <h2 style={{ margin: 0, fontWeight: 800, fontSize: "clamp(36px, 7vw, 84px)", letterSpacing: "-0.02em", backgroundImage: `linear-gradient(90deg, ${palette.purpleBright}, #fff)`, WebkitBackgroundClip: "text", color: "transparent" }}>{item.title}</h2>
-        <p style={{ marginTop: "1.1rem", fontSize: "clamp(16px, 2.1vw, 22px)", lineHeight: 1.45 }}>{item.desc}</p>
+        <h2 style={{ margin: 0, fontWeight: 800, fontSize: "clamp(36px, 7vw, 84px)", letterSpacing: "-0.02em", backgroundImage: `linear-gradient(90deg, ${palette.purpleBright}, #fff)`, WebkitBackgroundClip: "text", color: "transparent", display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{item.title}</h2>
+        <p style={{ marginTop: "1.1rem", fontSize: "clamp(16px, 2.1vw, 22px)", lineHeight: 1.45, display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{item.desc}</p>
         <a href={item.href} style={{ display: "inline-flex", alignItems: "center", gap: 10, marginTop: "2rem", border: `2px solid ${palette.purpleBright}`, color: palette.purpleBright, textDecoration: "none", padding: ".9rem 1.2rem", borderRadius: 999 }}>
           <span style={{ width: 10, height: 10, borderRadius: "50%", background: palette.purpleBright, display: "inline-block" }} />
           Conocer más
@@ -143,6 +143,8 @@ function Panel({ item, thin, palette }) {
             color: "#fff",
             opacity: 0.75,
             padding: "1rem 0",
+            fontFamily: "'argent-pixel-cf', sans-serif",
+            overflow: "hidden",
           }}
           aria-hidden
         >

--- a/src/StatsSection.jsx
+++ b/src/StatsSection.jsx
@@ -29,7 +29,7 @@ export default function StatsSection() {
       ref={sectionRef}
       className="min-h-screen flex flex-col items-center justify-center px-4"
     >
-      <h2 className="stat-title stat-animate text-4xl md:text-6xl font-bold mb-16 text-center font-sans">
+      <h2 className="stat-title stat-animate text-4xl md:text-6xl font-bold mb-16 text-center">
         {t('whyus.title', '¿Por qué nuestros servicios?')}
       </h2>
       <div className="stats-container grid grid-cols-1 md:grid-cols-2 gap-8 w-full max-w-4xl">

--- a/src/index.css
+++ b/src/index.css
@@ -61,6 +61,10 @@ html, body {
   color: var(--color-text);
 }
 
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'argent-pixel-cf', sans-serif;
+}
+
 /* Clases para titulares y texto */
 .headline {
   font-family: 'Ars Nova', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;


### PR DESCRIPTION
## Summary
- Aplica la fuente pixeleada a todos los encabezados y añade estilo cursivo para "presencia digital" en el landing.
- Ajusta el slider de servicios para limitar títulos y descripciones a dos líneas.
- Renueva los menús de Servicios y Automatiza tu operación con estilos degradados y distribución en dos filas.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a46f67e7483299d1245c47b4a4202