### PR TITLE
Add standalone scene for large 3D phone

### DIFF
--- a/src/Scene.tsx
+++ b/src/Scene.tsx
@@ -4,18 +4,18 @@ import React from "react";
 import { Canvas } from "@react-three/fiber";
 import { Environment, OrbitControls } from "@react-three/drei";
 import Phone3D from "./Phone3D";
+import phoneUi from "./assets/backgroundBlur.png";
 
 export default function Scene() {
   return (
     <div style={{ width: "100%", height: "100vh", background: "#0b0b0f" }}>
-      <Canvas camera={{ fov: 35, position: [0.9, 0.7, 1.1] }}>
+      <Canvas camera={{ fov: 35, position: [1.5, 1.2, 2] }}>
         <color attach="background" args={["#0b0b0f"]} />
         <Environment preset="city" />
         <hemisphereLight args={[0xffffff, 0x090909, 0.9]} />
         <directionalLight position={[1, 1, 1]} intensity={1} />
 
-        {/* 👇 Cambia esta URL por la ruta pública de TU imagen UI */}
-        <Phone3D uiTextureUrl="https://tu-cdn.com/tu-ui-morada.jpg" scale={5} />
+        <Phone3D uiTextureUrl={phoneUi} scale={8} />
 
         <OrbitControls enableDamping target={[0, 0.425, 0]} />
       </Canvas>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -12,6 +12,7 @@ import CapturaCalificaLeads from './pages/Automatizaciones/CapturaCalificaLeads'
 import InventarioChat from './pages/Automatizaciones/InventarioChat';
 import CotizacionesPostventa from './pages/Automatizaciones/CotizacionesPostventa';
 import ContactoMas from './pages/Automatizaciones/ContactoMas';
+import Scene from './Scene';
 import './index.css';
 import './i18n';
 
@@ -30,6 +31,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
         <Route path="automation/inventario-chat" element={<InventarioChat />} />
         <Route path="automation/cotizaciones-postventa" element={<CotizacionesPostventa />} />
         <Route path="automation/contacto" element={<ContactoMas />} />
+        <Route path="phone" element={<Scene />} />
         <Route path="*"          element={<Landing />} />  {/* fallback a landing */}
       </Routes>
     </HashRouter>


### PR DESCRIPTION
## Summary
- Render 3D phone with backgroundBlur texture at a larger scale
- Add route `/phone` to access the new 3D phone scene

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a4a4900ec8329a4588ce72002293c