### PR TITLE
fix: render Spline correctly

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,11 +2,12 @@
 <html lang="es">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/logo.svg" />
+    <!-- Use relative paths so assets resolve correctly on GitHub Pages -->
+    <link rel="icon" type="image/svg+xml" href="./logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#0C0D13" />
     <meta name="description" content="Weavion - Desarrollo web y diseño de experiencias digitales" />
-    <link rel="apple-touch-icon" href="/logo.svg" />
+    <link rel="apple-touch-icon" href="./logo.svg" />
     <link rel="manifest" href="./manifest.json" />
     <title>Weavion</title>
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,10 @@ import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
 
 // 3D
-import Spline from '@splinetool/react-spline/next';
+// The Next.js-specific entry point returns a Promise-based component which
+// causes React to try to render a Promise and crash. Use the standard
+// package export instead so Spline renders normally in the browser.
+import Spline from '@splinetool/react-spline';
 
 // Layout
 import DotGrid from './DotGrid';


### PR DESCRIPTION
## Summary
- fix Spline import to avoid rendering Promise crash
- use relative logo paths so assets load on GitHub Pages

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b9c811f008329869610cc2680919e