### PR TITLE
Fix language selector and persist choice

### DIFF
--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -1,10 +1,10 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import LanguageSelector from './LanguageSelector';
 
 export default function Header() {
-  const { t, i18n } = useTranslation();
-  const toggleLang = () => i18n.changeLanguage(i18n.language === 'es' ? 'en' : 'es');
+  const { t } = useTranslation();
 
   const servicesItems = [
     {
@@ -57,15 +57,8 @@ export default function Header() {
         <DropdownMenu title={t('header.automation', 'Automatiza tu operación')} items={automationItems} />
       </div>
 
-      {/* Selector idioma con borde degradado */}
-      <button
-        onClick={toggleLang}
-        className="transition group flex h-10 w-20 items-center justify-center rounded-full bg-gradient-to-r from-purple-500 via-pink-500 to-purple-500 p-[2px] text-white duration-300 hover:bg-gradient-to-l hover:shadow-2xl hover:shadow-purple-600/30"
-      >
-        <div className="flex h-full w-full items-center justify-center rounded-full bg-black">
-          {i18n.language === 'es' ? 'EN' : 'ES'}
-        </div>
-      </button>
+      {/* Selector idioma */}
+      <LanguageSelector />
     </div>
   );
 }

--- a/src/LanguageSelector.jsx
+++ b/src/LanguageSelector.jsx
@@ -1,24 +1,30 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
+/**
+ * Language selector dropdown that toggles between Spanish and English.
+ * The current language code is shown as the selected option.
+ */
 export default function LanguageSelector() {
   const { i18n } = useTranslation();
 
-  const changeLanguage = () => {
-    const newLang = i18n.language === 'es' ? 'en' : 'es';
-    i18n.changeLanguage(newLang);
-    console.log('Language changed to:', newLang);
+  const handleChange = (e) => {
+    const lang = e.target.value;
+    i18n.changeLanguage(lang);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('language', lang);
+    }
   };
 
   return (
-    <div className="fixed top-8 right-8 z-50">
-      <button
-        onClick={changeLanguage}
-        className="text-2xl font-bold bg-[#FFD100] text-[#202020] px-6 py-3 rounded-lg cursor-pointer border-2 border-[#202020]"
-      >
-        <option value="es">ES</option>
-        <option value="en">EN</option>
-      </select>
-    </div>
+    <select
+      value={i18n.language}
+      onChange={handleChange}
+      className="cursor-pointer h-10 w-20 text-center text-white text-lg font-bold bg-gradient-to-r from-purple-500 via-pink-500 to-purple-500 p-[2px] rounded-full hover:bg-gradient-to-l hover:shadow-2xl hover:shadow-purple-600/30"
+    >
+      <option value="es">ES</option>
+      <option value="en">EN</option>
+    </select>
   );
 }
+

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -4,18 +4,22 @@ import { initReactI18next } from 'react-i18next';
 import es from './locales/es.json';
 import en from './locales/en.json';
 
-i18n
-  .use(initReactI18next)
-  .init({
-    resources: {
-      es: { translation: es },
-      en: { translation: en },
-    },
-    lng: 'es',
-    fallbackLng: 'es',
-    interpolation: {
-      escapeValue: false,
-    },
-  });
+const storedLang =
+  typeof window !== 'undefined' && localStorage.getItem('language')
+    ? localStorage.getItem('language')
+    : 'es';
 
-export default i18n; 
+i18n.use(initReactI18next).init({
+  resources: {
+    es: { translation: es },
+    en: { translation: en },
+  },
+  lng: storedLang,
+  fallbackLng: 'es',
+  interpolation: {
+    escapeValue: false,
+  },
+});
+
+export default i18n;
+


### PR DESCRIPTION
## Summary
- replace broken language toggle with a dedicated dropdown component
- persist chosen locale in localStorage and initialize i18n from stored value
- wire new LanguageSelector into header to display current language code

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ba83764f08329b30832e950def4ae