### PR TITLE
feat: add Ars Pixel font for hero text

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <meta name="description" content="Weavion - Desarrollo web y diseño de experiencias digitales" />
     <link rel="apple-touch-icon" href="./logo.svg" />
     <link rel="manifest" href="./manifest.json" />
+    <link href="https://fonts.cdnfonts.com/css/ars-pixel" rel="stylesheet" />
     <title>Weavion</title>
 
       <!-- Fuente Ars Nova local -->

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -203,7 +203,7 @@ function Landing() {
                 className="font-argent text-5xl md:text-7xl text-[#D6D6D6] mb-6 leading-tight"
               >
                 Aumenta tu{' '}
-                <span className="font-argent-italic text-white">presencia digital</span>, sin trabajar de más
+                <span className="font-ars-pixel italic text-white">presencia digital</span>, sin trabajar de más
               </motion.h1>
 
               {/* Botón: solo borde degradado + punto negro; texto del botón en Argent Pixel CF */}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -25,6 +25,7 @@ module.exports = {
       fontFamily: {
         sans: ['Ars Nova', ...defaultTheme.fontFamily.sans],
         argent: ['argent-pixel-cf', ...defaultTheme.fontFamily.sans],
+        'ars-pixel': ['Ars Pixel', ...defaultTheme.fontFamily.sans],
       },
       colors: {
         'primary': '#D6D6D6',


### PR DESCRIPTION
## Summary
- load Ars Pixel font from CDN
- configure Tailwind to expose `font-ars-pixel`
- render hero "presencia digital" text with Ars Pixel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ba80fbe808329b612c1d05f3869eb