### PR TITLE
Ajusta alineación de texto con visor Spline y agrega estilos responsive

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -233,10 +233,10 @@ function Landing() {
   const { t } = useTranslation();
 
   return (
-    <section className="relative flex items-center min-h-screen px-4 md:px-8">
+    <section className="relative flex items-start min-h-screen px-4 md:px-8">
       <div className="absolute inset-0 bg-gradient-to-b from-black/50 via-transparent to-black/60 pointer-events-none" />
 
-      <div className="relative z-10 grid grid-cols-1 md:grid-cols-2 items-center min-h-screen gap-8">
+      <div className="relative z-10 grid grid-cols-1 md:grid-cols-2 items-start min-h-screen gap-8">
         {/* IZQUIERDA: titulares */}
         <div className="md:pr-10 w-full md:w-[50vw] max-w-3xl text-center md:text-left mx-auto md:mx-0">
           <motion.h1
@@ -259,11 +259,8 @@ function Landing() {
         </div>
 
         {/* DERECHA: modelo 3D (altura controlada) */}
-        <div className="w-full h-[150vh] md:h-[600-px] rounded-xl overflow-hidden bg-black/60">
+        <div className="w-full rounded-xl overflow-hidden bg-black/60">
           <SplineViewerBox />
-          <spline-viewer
-          url="https://prod.spline.desing/XKb4wzOQ2b05Zhac/scene.splinecode"
-          style={{width: "100%", height: "100vh"}}/>
         </div>
       </div>
     </section>

--- a/src/index.css
+++ b/src/index.css
@@ -74,8 +74,27 @@ h1, h2, h3, h4, h5, h6 {
   font-family: 'argent-pixel-cf', sans-serif;
 }
 
+/* Estilo base */
+spline-viewer,
 spline-viewer canvas#spline {
-  height: 1400px !important;
+  width: 100% !important;
+  display: block;
+}
+
+/* PC */
+@media (min-width: 1024px) {
+  spline-viewer,
+  spline-viewer canvas#spline {
+    height: 2500px !important;
+  }
+}
+
+/* Móvil */
+@media (max-width: 1023px) {
+  spline-viewer,
+  spline-viewer canvas#spline {
+    height: 1400px !important;
+  }
 }
 /* Clases para titulares y texto */
 .headline {


### PR DESCRIPTION
## Summary
- Alinea el texto y el visor Spline en la sección principal para evitar desplazamientos verticales
- Añade estilos responsive al componente `spline-viewer` con alturas específicas para PC y móvil

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bd3c4e77083299cde9e01341ba94f