### PR TITLE
Reset styles and load fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,11 @@
     <link rel="manifest" href="./manifest.json" />
     <title>Weavion</title>
 
+    <!-- Load custom fonts -->
+    <link rel="preconnect" href="https://fonts.cdnfonts.com" />
+    <link href="https://fonts.cdnfonts.com/css/arial-nova" rel="stylesheet" />
+    <link href="https://fonts.cdnfonts.com/css/argent-pixel-cf" rel="stylesheet" />
+
     <!-- Preload Argent Pixel CF font files -->
     <link
       rel="preload"

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,6 @@
+@import url('https://fonts.cdnfonts.com/css/arial-nova');
+@import url('https://fonts.cdnfonts.com/css/argent-pixel-cf');
+
 /* Importación de la fuente Arial Nova con fallbacks locales */
 /* src/index.css */
 @font-face {
@@ -58,6 +61,15 @@
 head::before {
   content: '';
   display: none;
+}
+
+/* Reset global styles */
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
 }
 
 /* Definir variables para la paleta de colores */


### PR DESCRIPTION
## Summary
- import Arial Nova and Argent Pixel fonts from CDN and preload via HTML
- add global CSS reset to ensure consistent styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689be9e03e888329837bb6299e2b3c42