### PR TITLE
Align hero text left and adjust mobile CTA spacing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -236,9 +236,9 @@ function Landing() {
     <section className="relative flex items-center min-h-screen px-4 md:px-8 pt-32 md:pt-40">
       <div className="absolute inset-0 bg-gradient-to-b from-black/50 via-transparent to-black/60 pointer-events-none" />
 
-      <div className="relative z-10 grid w-full grid-cols-1 md:grid-cols-2 items-center gap-8">
-        {/* IZQUIERDA: titulares */}
-        <div className="md:pr-10 w-full md:w-[50vw] max-w-3xl text-center md:text-left mx-auto md:mx-0">
+        <div className="relative z-10 grid w-full grid-cols-1 md:grid-cols-2 items-center gap-8">
+          {/* IZQUIERDA: titulares */}
+          <div className="md:pr-10 w-full md:w-[50vw] max-w-3xl text-left">
           <motion.h1
             initial={{ opacity: 0, y: 60 }}
             animate={{ opacity: 1, y: 0 }}
@@ -248,22 +248,22 @@ function Landing() {
             Aumenta tu <span className="font-ars text-4xl md:text-5xl">presencia digital</span>, sin trabajar de más
           </motion.h1>
 
-          <Link
-            to="/services"
-            className="transition group mt-4 flex h-12 w-44 items-center justify-center rounded-full bg-gradient-to-r from-purple-400 to-purple-700 p-[1.5px] text-white duration-300 hover:bg-gradient-to-l hover:shadow-2xl hover:shadow-purple-600/30"
-          >
-            <div className="flex h-full w-full items-center justify-center rounded-full bg-[#010207] transition duration-300 ease-in-out group-hover:bg-gradient-to-br group-hover:from-gray-700 group-hover:to-gray-900 font-argent">
-              {t("hero.cta", "Descúbrelo")}
-            </div>
-          </Link>
-        </div>
+            <Link
+              to="/services"
+              className="transition group mt-4 relative top-10 md:top-0 z-20 flex h-12 w-44 items-center justify-center rounded-full bg-gradient-to-r from-purple-400 to-purple-700 p-[1.5px] text-white duration-300 hover:bg-gradient-to-l hover:shadow-2xl hover:shadow-purple-600/30"
+            >
+              <div className="flex h-full w-full items-center justify-center rounded-full bg-[#010207] transition duration-300 ease-in-out group-hover:bg-gradient-to-br group-hover:from-gray-700 group-hover:to-gray-900 font-argent">
+                {t("hero.cta", "Descúbrelo")}
+              </div>
+            </Link>
+          </div>
 
         {/* DERECHA: modelo 3D (altura controlada) */}
-        <SplineViewerBox className="w-full h-[500px] md:h-[700px] rounded-xl overflow-hidden bg-black/60 mx-auto" />
-      </div>
-    </section>
-  );
-}
+        <SplineViewerBox className="w-full h-[500px] md:h-[700px] rounded-xl overflow-hidden bg-black/60 mx-auto z-10" />
+        </div>
+      </section>
+    );
+  }
 
 /* -------------------------------------------------------
    App principal


### PR DESCRIPTION
## Summary
- align landing hero text to the left on mobile
- move "Discover how" CTA downward with higher z-index so it floats over the phone model
- set phone model z-index to avoid overlap issues

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bec7dd6d883299083fa71888a44cc