### PR TITLE
style: widen service and automation buttons

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -243,14 +243,14 @@ function Landing() {
             initial={{ opacity: 0, y: 60 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.8 }}
-            className="font-argent text-4xl md:text-7xl text-[#D6D6D6] mb-10 md:mb-16 leading-tight"
+            className="font-argent text-4xl md:text-7xl text-[#D6D6D6] mb-10 md:mb-16 md:ml-4 leading-tight"
           >
             Aumenta tu <span className="font-ars text-4xl md:text-5xl">presencia digital</span>, sin trabajar de más
           </motion.h1>
 
           <Link
             to="/services"
-            className="transition group mt-2 md:mt-4 flex h-12 w-44 items-center justify-center rounded-full bg-gradient-to-r from-purple-400 to-purple-700 p-[1.5px] text-white duration-300 hover:bg-gradient-to-l hover:shadow-2xl hover:shadow-purple-600/30"
+            className="transition group mt-4 md:mt-6 flex h-12 w-44 items-center justify-center rounded-full bg-gradient-to-r from-purple-400 to-purple-700 p-[1.5px] text-white duration-300 hover:bg-gradient-to-l hover:shadow-2xl hover:shadow-purple-600/30"
           >
             <div className="flex h-full w-full items-center justify-center rounded-full bg-[#010207] transition duration-300 ease-in-out group-hover:bg-gradient-to-br group-hover:from-gray-700 group-hover:to-gray-900 font-argent">
               {t("hero.cta", "Descúbrelo")}

--- a/src/pages/Automatizaciones/common.jsx
+++ b/src/pages/Automatizaciones/common.jsx
@@ -47,7 +47,7 @@ export const CTAButton = ({ children }) => (
   <motion.button
     whileHover={{ scale: 1.04 }}
     whileTap={{ scale: 0.98 }}
-    className="group relative inline-flex items-center gap-2 rounded-full border-2 px-5 py-3 text-base"
+    className="group relative inline-flex items-center gap-2 rounded-full border-2 px-8 md:px-12 py-3 text-base whitespace-nowrap md:min-w-[260px]"
     style={{ borderColor: PALETTE.purpleBright, color: PALETTE.grayLight }}
   >
     <span

--- a/src/pages/ServiciosExtendidos.jsx
+++ b/src/pages/ServiciosExtendidos.jsx
@@ -16,7 +16,7 @@ const GradientBg = ({ children }) => (
 );
 
 const CTAButton = ({ children }) => (
-  <motion.button whileHover={{ scale: 1.04 }} whileTap={{ scale: 0.98 }} className="group inline-flex items-center gap-2 rounded-full border-2 px-5 py-3 text-base" style={{ borderColor: PALETTE.purpleBright, color: PALETTE.grayLight }}>
+  <motion.button whileHover={{ scale: 1.04 }} whileTap={{ scale: 0.98 }} className="group inline-flex items-center gap-2 rounded-full border-2 px-8 md:px-12 py-3 text-base whitespace-nowrap md:min-w-[260px]" style={{ borderColor: PALETTE.purpleBright, color: PALETTE.grayLight }}>
     <span className="h-2 w-2 rounded-full" style={{ background: PALETTE.purpleBright }} />{children}
     <ArrowRight className="transition-transform group-hover:translate-x-0.5" size={18} />
   </motion.button>


### PR DESCRIPTION
## Summary
- expand CTA buttons in Services and Automation subsections
- add desktop left margin and extra spacing for hero headline button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bf2b7fbd48329a0f82cc4c149a2fb