### PR TITLE
Add service pages with charts and term glossary

### DIFF
--- a/src/ServiciosPinnedSlider.jsx
+++ b/src/ServiciosPinnedSlider.jsx
@@ -10,34 +10,22 @@ const PALETTE = {
 export default function ServiciosPinnedSlider() {
   const items = [
     {
-      title: "Diseño y Desarrollo web",
+      title: "Diseño & Desarrollo Web",
       desc: "Sitios ultra-rápidos y accesibles. Microinteracciones, SEO y performance 90+ en Lighthouse.",
       bg: `radial-gradient(60% 80% at 20% 20%, rgba(255,255,255,.08), rgba(0,0,0,0) 60%), linear-gradient(120deg, ${PALETTE.blackPurple}, ${PALETTE.purpleDark})`,
       href: "/services/web",
     },
     {
-      title: "Integración a CRM o ServiceTitan",
-      desc: "De lead a ingreso sin fricción: captura limpia, enriquecimiento, tareas automáticas y asignación de técnicos.",
+      title: "Integración a ServiceTitan",
+      desc: "De lead a ingreso sin fricción: captura limpia, asignación automática y control total de la operación.",
       bg: `radial-gradient(60% 80% at 80% 30%, rgba(255,255,255,.08), rgba(0,0,0,0) 60%), linear-gradient(120deg, #21183e, ${PALETTE.purpleDark})`,
-      href: "/services/crm",
+      href: "/services/servicetitan",
     },
     {
-      title: "Email Marketing",
-      desc: "Automatizaciones que venden: onboarding, carritos abandonados, newsletters y triggers por comportamiento.",
+      title: "Analíticas de Negocio",
+      desc: "Paneles en tiempo real: CAC, ROAS y revenue por canal para decidir con datos.",
       bg: `radial-gradient(60% 80% at 20% 70%, rgba(255,255,255,.06), rgba(0,0,0,0) 60%), linear-gradient(120deg, #1a1530, #2a2146)` ,
-      href: "/services/email",
-    },
-    {
-      title: "Integración a CRM o Service Titan",
-      desc: "Formularios → leads limpios → tareas automáticas → técnicos asignados.",
-      bg: `radial-gradient(60% 80% at 70% 30%, rgba(255,255,255,.06), rgba(0,0,0,0) 60%), linear-gradient(120deg, #2a2146, #331d5f)` ,
-      href: "/services/crm",
-    },
-    {
-      title: "Automatiza tu operación",
-      desc: "Bots y flujos con n8n/Python para cotizaciones, recordatorios, inventario y postventa 24/7.",
-      bg: `radial-gradient(60% 80% at 50% 50%, rgba(255,255,255,.06), rgba(0,0,0,0) 60%), linear-gradient(120deg, #232032, ${PALETTE.blackPurple})` ,
-      href: "/automatizaciones/genera-citas",
+      href: "/services/analytics",
     },
   ];
 

--- a/src/components/TermHint.jsx
+++ b/src/components/TermHint.jsx
@@ -1,0 +1,43 @@
+import React, { useId, useState } from 'react';
+
+/**
+ * TermHint
+ * Muestra un “link” subrayado (accesible) que despliega una burbuja con definición.
+ * - Hover / Focus / Tap: abre la burbuja
+ * - Esc o click fuera: cierra
+ */
+export default function TermHint({ term, children, placement = 'top' }) {
+  const id = useId();
+  const [open, setOpen] = useState(false);
+
+  const toggle = (e) => {
+    // soportar tap en móvil sin saltar la página
+    if (e) e.preventDefault();
+    setOpen((v) => !v);
+  };
+
+  return (
+    <span className="termhint-wrapper" onMouseLeave={() => setOpen(false)}>
+      <button
+        type="button"
+        className="termhint-link"
+        aria-expanded={open}
+        aria-controls={`hint-${id}`}
+        onMouseEnter={() => setOpen(true)}
+        onFocus={() => setOpen(true)}
+        onClick={toggle}
+        onKeyDown={(e) => e.key === 'Escape' && setOpen(false)}
+      >
+        {term}
+      </button>
+
+      <span
+        id={`hint-${id}`}
+        role="tooltip"
+        className={`termhint-bubble ${open ? 'is-open' : ''} ${placement}`}
+      >
+        {children}
+      </span>
+    </span>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -619,3 +619,156 @@ spline-viewer canvas#spline {
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+/* Tipografía Ars Pixel (ajusta ruta si la tienes en otra carpeta) */
+@font-face{
+  font-family:'Ars Pixel';
+  src:url('./assets/fonts/ArsPixel-Regular.woff2') format('woff2'),
+      url('./assets/fonts/ArsPixel-Regular.woff') format('woff');
+  font-weight:400;font-style:normal;font-display:swap;
+}
+
+:root{
+  --text:#ECECEC;
+  --metal1:#0b0a12; --metal2:#1a1828; --metal3:#1d1a2e; --metal4:#201d36;
+}
+
+/* contenedor página */
+.page-wrap{min-height:100vh;padding:48px 18px;}
+@media(min-width:768px){.page-wrap{padding:64px 28px;}}
+.hero{max-width:900px;margin:0 auto 28px;}
+.headline-xl{font-family:'Ars Pixel',system-ui,sans-serif;font-weight:700;line-height:1.08;font-size:clamp(28px,4.5vw,48px);color:#fff;}
+.sublead{font-family:'Ars Pixel',system-ui,sans-serif;color:#e7e4ff;opacity:.92;margin-top:.5rem;font-size:clamp(14px,1.4vw,18px);line-height:1.6}
+.section{max-width:1100px;margin:20px auto}
+.text-white{color:#fff}
+
+/* fondos metálicos */
+.metal-bg-1{background:radial-gradient(120% 140% at 80% 20%,#2c2a40 0%,#151322 55%,var(--metal1) 100%);}
+.metal-bg-2{background:radial-gradient(120% 140% at 20% 20%,#34324a 0%,#1a1828 55%,var(--metal1) 100%);}
+.metal-bg-3{background:radial-gradient(120% 140% at 80% 80%,#3a3854 0%,#1d1a2e 55%,var(--metal1) 100%);}
+.metal-bg-4{background:radial-gradient(120% 140% at 20% 80%,#423f62 0%,#201d36 55%,var(--metal1) 100%);}
+
+/* glass card */
+.glass{
+  background:linear-gradient(180deg,rgba(255,255,255,.07),rgba(255,255,255,.02));
+  border:1px solid rgba(167,139,250,.22);
+  box-shadow:0 6px 24px rgba(124,58,237,.18), inset 0 1px 0 rgba(255,255,255,.08);
+  backdrop-filter:blur(6px);
+}
+
+/* tipografía componentes */
+.card-title{font-family:'Ars Pixel',system-ui,sans-serif;font-weight:700;font-size:clamp(18px,2.2vw,26px);margin-bottom:.4rem}
+.card-copy{font-family:'Ars Pixel',system-ui,sans-serif;color:#e7e4ff;opacity:.9}
+
+/* kpis */
+.kpi{padding:16px;border-radius:18px;text-align:center}
+.kpi-v{font-family:'Ars Pixel',system-ui,sans-serif;font-size:clamp(20px,2.8vw,28px);font-weight:700}
+.kpi-l{font-family:'Ars Pixel',system-ui,sans-serif;font-size:12px;color:#d9d4ff;opacity:.9}
+
+/* bullets */
+.list-bullets{margin:0;padding-left:1.1rem;display:grid;gap:.4rem}
+.list-bullets li{list-style:disc}
+
+/* charts */
+.chart{margin-top:.75rem}
+.chart svg{width:100%;height:auto;display:block}
+.chart-note{font-size:12px;color:#cfc8f4;opacity:.85;margin-top:.5rem}
+
+/* --- TermHint (glosario interactivo) --- */
+.termhint-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.termhint-link {
+  background: none;
+  border: 0;
+  padding: 0 2px;
+  cursor: pointer;
+  font: inherit;
+  color: #cbb6ff;
+  /* subrayado “barra” con degradé metálico */
+  background-image: linear-gradient(90deg, #b692ff, #7c3aed);
+  background-size: 100% 2px;
+  background-position: 0 100%;
+  background-repeat: no-repeat;
+  transition: color .2s ease, opacity .2s ease;
+}
+.termhint-link:hover,
+.termhint-link:focus-visible {
+  color: #ffffff;
+  outline: none;
+  opacity: 1;
+}
+
+.termhint-bubble {
+  position: absolute;
+  z-index: 40;
+  min-width: 220px;
+  max-width: 320px;
+  padding: 10px 14px;
+  border-radius: 14px;
+  color: #f6f4ff;
+  font-size: 12.5px;
+  line-height: 1.45;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(4px) scale(.98);
+  transition: opacity .18s ease, transform .18s ease;
+  /* efecto glass + metálico */
+  background: linear-gradient(180deg, rgba(255,255,255,.10), rgba(255,255,255,.04));
+  border: 1px solid rgba(167,139,250,.35);
+  box-shadow:
+    0 8px 28px rgba(124,58,237,.22),
+    inset 0 1px 0 rgba(255,255,255,.12);
+  backdrop-filter: blur(6px);
+  /* posición por defecto (top) */
+  left: 50%;
+  bottom: calc(100% + 10px);
+  transform-origin: bottom center;
+  translate: -50% 0;
+}
+.termhint-bubble.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+.termhint-bubble::after {
+  content: "";
+  position: absolute;
+  width: 12px; height: 12px;
+  background: inherit;
+  border-left: inherit; border-top: inherit;
+  bottom: -7px; left: 50%;
+  translate: -50% 0;
+  transform: rotate(45deg);
+}
+
+/* Posiciones alternativas si las necesitas */
+.termhint-bubble.right {
+  left: calc(100% + 10px);
+  bottom: 50%;
+  transform-origin: center left;
+  translate: 0 50%;
+}
+.termhint-bubble.right::after {
+  bottom: 50%; left: -6px; translate: 0 50%;
+  border-left: inherit; border-top: inherit;
+}
+
+.termhint-bubble.left {
+  right: calc(100% + 10px);
+  left: auto;
+  bottom: 50%;
+  transform-origin: center right;
+  translate: 0 50%;
+}
+.termhint-bubble.left::after {
+  bottom: 50%; right: -6px; left: auto; translate: 0 50%;
+  border-left: inherit; border-top: inherit;
+}
+
+/* accesibilidad: respeta usuarios que prefieren menos motion */
+@media (prefers-reduced-motion: reduce) {
+  .termhint-bubble { transition: none; }
+  .termhint-link { transition: none; }
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,7 +4,9 @@ import { HashRouter, Routes, Route } from 'react-router-dom';
 import Landing from './App';
 import ServiciosPinnedSlider from './ServiciosPinnedSlider';
 import ContactPage from './ContactPage';
-import DisenoDesarrolloWebExt, { IntegracionCRMExt, AnaliticasNegocioExt } from './pages/ServiciosExtendidos';
+import WebDesign from './pages/WebDesign';
+import ServiceTitan from './pages/ServiceTitan';
+import Analytics from './pages/Analytics';
 import GeneraCitas from './pages/Automatizaciones/GeneraCitas';
 import CapturaCalificaLeads from './pages/Automatizaciones/CapturaCalificaLeads';
 import InventarioChat from './pages/Automatizaciones/InventarioChat';
@@ -21,9 +23,9 @@ ReactDOM.createRoot(document.getElementById('root')).render(
       <Routes>
         <Route path=""           element={<Landing />} />
         <Route path="services"   element={<ServiciosPinnedSlider />} />
-        <Route path="services/web"        element={<DisenoDesarrolloWebExt />} />
-        <Route path="services/crm"        element={<IntegracionCRMExt />} />
-        <Route path="services/analiticas" element={<AnaliticasNegocioExt />} />
+        <Route path="services/web"          element={<WebDesign />} />
+        <Route path="services/servicetitan" element={<ServiceTitan />} />
+        <Route path="services/analytics"    element={<Analytics />} />
         <Route path="contact"    element={<ContactPage />} />
         <Route path="automation/genera-citas" element={<GeneraCitas />} />
         <Route path="automation/captura-califica-leads" element={<CapturaCalificaLeads />} />

--- a/src/pages/Analytics.jsx
+++ b/src/pages/Analytics.jsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import TermHint from '../components/TermHint';
+
+/* Combo Area + Line para ROI */
+function ComboROI({ months, cac, roi }) {
+  const W=360, H=200, chartH=130, top=30, left=28;
+  const max = Math.max(...cac, ...roi, 1);
+  const scale = v => top + chartH - (v/max)*chartH;
+  const step = (W - left*2) / (months.length - 1);
+
+  const linePath = roi.map((v,i)=>`${i===0?'M':'L'} ${left+i*step} ${scale(v)}`).join(' ');
+  const areaPath = `M ${left} ${scale(cac[0])} ` + cac.map((v,i)=>`L ${left+i*step} ${scale(v)}`).join(' ') + ` L ${left+(months.length-1)*step} ${H-20} L ${left} ${H-20} Z`;
+
+  return (
+    <div className="chart">
+      <svg viewBox={`0 0 ${W} ${H}`}>
+        <defs>
+          <linearGradient id="areaCAC" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stopColor="#9333ea" stopOpacity="0.35"/>
+            <stop offset="100%" stopColor="#9333ea" stopOpacity="0.05"/>
+          </linearGradient>
+          <linearGradient id="lineROI" x1="0" x2="1">
+            <stop offset="0%" stopColor="#a78bfa"/>
+            <stop offset="100%" stopColor="#ffffff"/>
+          </linearGradient>
+        </defs>
+
+        <path d={areaPath} fill="url(#areaCAC)"/>
+        <path d={linePath} fill="none" stroke="url(#lineROI)" strokeWidth="3" strokeLinecap="round"/>
+
+        {months.map((m,i)=>(
+          <text key={m} x={left+i*step} y={H-6} fontSize="10" fill="#bdb8d8" textAnchor="middle">{m}</text>
+        ))}
+      </svg>
+      <p className="chart-note">ROI sube mientras el CAC se contiene: más rentabilidad por campaña.</p>
+    </div>
+  );
+}
+
+function KPIList({ items }) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      {items.map((it, idx)=>(
+        <div key={idx} className="glass rounded-2xl p-5">
+          <p className="kpi-v">{it.value}</p>
+          <p className="kpi-l">{it.label}</p>
+          <p className="card-copy mt-2">{it.desc}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function Analytics() {
+  return (
+    <div className="page-wrap metal-bg-4 text-white">
+      <header className="hero">
+        <h1 className="headline-xl">Analíticas que guían inversión y crecimiento</h1>
+        <p className="sublead">
+          Paneles en tiempo real: <TermHint term="CAC">Costo de Adquisición de Cliente: inversión total / clientes nuevos.</TermHint>, <TermHint term="ROAS">Retorno de la inversión publicitaria: revenue atribuible / gasto publicitario.</TermHint>, tasa de cierre y revenue por canal. Decisiones
+          con datos, no corazonadas.
+        </p>
+      </header>
+
+      <section className="section">
+        <KPIList items={[
+          { value:'-18%', label:'CAC', desc:'Costo por adquisición controlado mes a mes.' },
+          { value:'+34%', label:'ROAS', desc:'Mayor retorno por cada dólar invertido.' },
+          { value:'+22%', label:'Tasa de cierre', desc:'Seguimiento y nurturing que convierten.' },
+        ]}/>
+      </section>
+
+      <section className="section grid md:grid-cols-2 gap-6">
+        <motion.article initial={{opacity:0,y:20}} whileInView={{opacity:1,y:0}} viewport={{once:true}} className="glass p-6 rounded-2xl">
+          <h3 className="card-title">ROI vs CAC (últimos 6 meses)</h3>
+          <p className="card-copy">
+            Redistribuimos presupuesto a los canales con mejor <TermHint term="ROAS">retorno por gasto publicitario</TermHint> y pausamos
+            los que drenan inversión.
+          </p>
+          <ComboROI
+            months={['Ene','Feb','Mar','Abr','May','Jun']}
+            cac={[62,58,55,53,52,49]}
+            roi={[1.2,1.4,1.5,1.7,1.9,2.1]}
+          />
+        </motion.article>
+
+        <motion.article initial={{opacity:0,y:20}} whileInView={{opacity:1,y:0}} viewport={{once:true}} className="glass p-6 rounded-2xl">
+          <h3 className="card-title">Qué obtienes</h3>
+          <ul className="list-bullets">
+            <li>Tableros ejecutivos por canal, campaña y equipo.</li>
+            <li>Alertas de desviación para reaccionar a tiempo.</li>
+            <li>Reportes automáticos a tu correo cada semana.</li>
+          </ul>
+        </motion.article>
+      </section>
+    </div>
+  );
+}

--- a/src/pages/ServiceTitan.jsx
+++ b/src/pages/ServiceTitan.jsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import TermHint from '../components/TermHint';
+
+/* Embudo simple para visualizar control operacional */
+function Funnel({ stages = [] }) {
+  const width = 360, height = 200, topW = 300, stepH = 36;
+  return (
+    <div className="chart">
+      <svg viewBox={`0 0 ${width} ${height}`}>
+        <defs>
+          <linearGradient id="gradFunnel" x1="0" x2="1">
+            <stop offset="0%" stopColor="#a78bfa"/>
+            <stop offset="100%" stopColor="#6d28d9"/>
+          </linearGradient>
+        </defs>
+        {stages.map((s, i) => {
+          const w = topW - i * 34;
+          const x = (width - w)/2;
+          const y = 20 + i * (stepH + 8);
+          return (
+            <g key={s.label}>
+              <rect x={x} y={y} width={w} height={stepH} rx="12" fill="url(#gradFunnel)" opacity={0.95}/>
+              <text x={width/2} y={y+22} textAnchor="middle" fontSize="12" fill="#fff">
+                {s.label} · {s.value}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+      <p className="chart-note">Visibilidad por etapa: menos fugas, más cierres.</p>
+    </div>
+  );
+}
+
+function SLAKpis() {
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      {[
+        {v:'< 5 min', l:(<>Primer respuesta <TermHint term="SLA">Acuerdo de nivel de servicio: tiempos objetivo de respuesta y resolución.</TermHint></>)},
+        {v:'98%',   l:'Citas confirmadas'},
+        {v:'-35%',  l:'No-shows'},
+        {v:'+27%',  l:'Cierres por técnico'},
+      ].map((k, i)=>(
+        <div key={i} className="kpi glass">
+          <p className="kpi-v">{k.v}</p>
+          <p className="kpi-l">{k.l}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function ServiceTitan() {
+  return (
+    <div className="page-wrap metal-bg-3 text-white">
+      <header className="hero">
+        <h1 className="headline-xl">ServiceTitan integrado: operación sin fricción</h1>
+        <p className="sublead">
+          Agenda, asigna, factura y reporta desde un mismo flujo. Menos errores, más tiempo productivo.
+        </p>
+      </header>
+
+      {/* KPIs de eficiencia operativa */}
+      <section className="section">
+        <SLAKpis/>
+      </section>
+
+      {/* Pipeline/Embudo + promesa comercial */}
+      <section className="section grid md:grid-cols-2 gap-6">
+        <motion.article initial={{opacity:0,y:24}} whileInView={{opacity:1,y:0}} viewport={{once:true}} className="glass p-6 rounded-2xl">
+          <h3 className="card-title">Pipeline controlado de punta a punta</h3>
+          <p className="card-copy">
+            Cada lead avanza con reglas claras. Asignación automática, recordatorios y
+            documentación unificada para cumplir <TermHint term="SLA">tiempos comprometidos</TermHint> y reducir no-shows.
+          </p>
+          <Funnel stages={[
+            {label:'Web / Lead', value:'100%'},
+            {label:'Agenda', value:'82%'},
+            {label:'Visita', value:'74%'},
+            {label:'Cotiza', value:'55%'},
+            {label:'Cierra', value:'41%'},
+          ]}/>
+        </motion.article>
+
+        <motion.article initial={{opacity:0,y:24}} whileInView={{opacity:1,y:0}} viewport={{once:true}} className="glass p-6 rounded-2xl">
+          <h3 className="card-title">Qué activamos</h3>
+          <ul className="list-bullets">
+            <li>Integración de formularios/llamadas → ServiceTitan.</li>
+            <li>Rutas y asignación automática por zona y carga.</li>
+            <li>Plantillas y cobros listos para salir a campo.</li>
+            <li>Reportes de desempeño por técnico y cuadrilla.</li>
+          </ul>
+        </motion.article>
+      </section>
+    </div>
+  );
+}

--- a/src/pages/WebDesign.jsx
+++ b/src/pages/WebDesign.jsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import TermHint from '../components/TermHint';
+
+/* ---------- Gráficos SVG ---------- */
+function TrendBars({ labels, values, note }) {
+  const max = Math.max(...values, 1);
+  return (
+    <div className="chart">
+      <svg viewBox="0 0 340 180">
+        <defs>
+          <linearGradient id="gradBars" x1="0" x2="1">
+            <stop offset="0%" stopColor="#b692ff"/>
+            <stop offset="100%" stopColor="#7c3aed"/>
+          </linearGradient>
+        </defs>
+        {values.map((v, i) => {
+          const w=28, gap=18, x=30+i*(w+gap);
+          const h = (v/max)*110 + 10;
+          const y = 150 - h;
+          return (
+            <g key={i}>
+              <rect x={x} y={y} width={w} height={h} rx="8" fill="url(#gradBars)"/>
+              <text x={x+w/2} y={y-6} textAnchor="middle" fontSize="10" fill="#e9e9ff">{v}</text>
+              <text x={x+w/2} y="168" textAnchor="middle" fontSize="10" fill="#bdb8d8">{labels[i]}</text>
+            </g>
+          );
+        })}
+      </svg>
+      {note ? <p className="chart-note">{note}</p> : null}
+    </div>
+  );
+}
+
+function KPIGrid({ items }) {
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      {items.map((it, idx)=>(
+        <div key={idx} className="kpi glass">
+          <p className="kpi-v">{it.value}</p>
+          <p className="kpi-l">{it.label}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* ---------- Página ---------- */
+export default function WebDesign() {
+  return (
+    <div className="page-wrap metal-bg-1 text-white">
+      {/* Hero */}
+      <header className="hero">
+        <h1 className="headline-xl">Sitios web que convierten visitas en ventas</h1>
+        <p className="sublead">
+          Rendimiento real, <TermHint term="SEO">Optimización para buscadores: estructura, contenido y performance que elevan ranking y tráfico orgánico.</TermHint> técnico y UX enfocada en acción. Tu marca luce premium
+          y cada pantalla empuja a “comprar”, “agendar” o “pedir cotización”.
+        </p>
+      </header>
+
+      {/* KPIs de promesa comercial */}
+      <section className="section">
+        <KPIGrid items={[
+          { value:'+38%', label:'Tasa de conversión' },
+          { value:'-42%', label:'Rebote en landing' },
+          { value:'+2.3x', label:'Velocidad percibida' },
+          { value:'+61%', label:'Ingresos por sesión' },
+        ]}/>
+      </section>
+
+      {/* Tendencia de ventas (muestra impacto de performance + UX) */}
+      <section className="section grid md:grid-cols-2 gap-6">
+        <motion.article initial={{opacity:0,y:20}} whileInView={{opacity:1,y:0}} viewport={{once:true}} className="glass p-6 rounded-2xl">
+          <h3 className="card-title">Ventas cerradas por mes</h3>
+          <p className="card-copy">
+            La velocidad y claridad reducen fricción. Más usuarios completan el flujo de compra.
+          </p>
+          <TrendBars
+            labels={['Ene','Feb','Mar','Abr','May','Jun']}
+            values={[24,31,38,46,54,66]}
+            note="Tendencia sostenida tras optimizar tiempos de carga y jerarquía visual."
+          />
+        </motion.article>
+
+        <motion.article initial={{opacity:0,y:20}} whileInView={{opacity:1,y:0}} viewport={{once:true}} className="glass p-6 rounded-2xl">
+          <h3 className="card-title">Qué entregamos</h3>
+          <ul className="list-bullets">
+            <li>Arquitectura <TermHint term="SEO">Mapa de URLs, metadatos, schema y rápidos tiempos TTFB/CLS/INP para mejor posicionamiento.</TermHint> + contenido que posiciona y vende.</li>
+            <li>Checkout fluido e integraciones de pago.</li>
+            <li>Diseño adaptable con micro-interacciones que guían.</li>
+            <li>Métricas de conversión para iterar cada mes.</li>
+          </ul>
+        </motion.article>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable TermHint component for glossary popovers
- create WebDesign, ServiceTitan, and Analytics pages with SVG charts and KPI cards
- wire new services into router and slider, add dark metallic styles and TermHint CSS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ca8fdd8b48329b2daa6ccab3d222f