### PR TITLE
Unifica y mejora menús de servicios y automatización

### DIFF
--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { Triangle } from 'lucide-react';
 import LanguageSelector from './LanguageSelector';
 import logo from './assets/weavionLogoBase64.js';
 
@@ -53,9 +54,11 @@ export default function Header() {
         </Link>
 
       {/* Menús intermedios */}
-        <div className="flex-1 flex items-center justify-center space-x-4 md:space-x-8">
-          <DropdownMenu title={t('header.services', 'Servicios')} items={servicesItems} />
-          <DropdownMenu title={t('header.automation', 'Automatiza')} items={automationItems} />
+        <div className="flex-1 flex items-center justify-center">
+          <div className="glass-high rounded-2xl flex flex-col md:flex-row">
+            <DropdownMenu title={t('header.services', 'Servicios')} items={servicesItems} />
+            <DropdownMenu title={t('header.automation', 'Automatiza')} items={automationItems} />
+          </div>
         </div>
 
       {/* Selector idioma */}
@@ -67,6 +70,7 @@ export default function Header() {
 function DropdownMenu({ title, items }) {
   const [open, setOpen] = useState(false);
   const menuRef = useRef(null);
+  const closeTimer = useRef();
 
   useEffect(() => {
     const handleClick = (e) => {
@@ -78,31 +82,39 @@ function DropdownMenu({ title, items }) {
     return () => document.removeEventListener('mousedown', handleClick);
   }, []);
 
+  const handleEnter = () => {
+    clearTimeout(closeTimer.current);
+    setOpen(true);
+  };
+
+  const handleLeave = () => {
+    closeTimer.current = setTimeout(() => setOpen(false), 2000);
+  };
+
   return (
     <div
       ref={menuRef}
-      className="relative mx-4"
-      onMouseEnter={() => setOpen(true)}
-      onMouseLeave={() => setOpen(false)}
+      className="relative flex-1"
+      onMouseEnter={handleEnter}
+      onMouseLeave={handleLeave}
     >
       <button
         onClick={() => setOpen((o) => !o)}
-        className="cursor-pointer text-white px-3 py-2 rounded-md font-argent glass text-sm md:text-base"
+        className="flex w-full items-center justify-between px-6 py-3 font-argent text-white text-sm md:text-base"
       >
-        {title}
+        <span>{title}</span>
+        <Triangle className="w-3 h-3 rotate-180" />
       </button>
       {open && (
-        <div className="absolute left-1/2 -translate-x-1/2 mt-4 w-full max-w-md md:max-w-2xl glass rounded-2xl grid grid-cols-1 md:grid-cols-2 gap-4 p-4 text-white">
+        <div className="absolute left-1/2 -translate-x-1/2 mt-4 w-full max-w-xl md:max-w-3xl glass-high rounded-2xl flex flex-col md:flex-row gap-4 p-4 text-white">
           {items.map(({ label, path }, idx) => (
             <Link
               key={idx}
               to={path}
               onClick={() => setOpen(false)}
-              className="group w-full min-h-20 md:min-h-24 rounded-2xl p-[2px] bg-gradient-to-r from-purple-400 to-purple-700 text-white transition duration-300 hover:bg-gradient-to-l hover:shadow-2xl hover:shadow-purple-600/30"
+              className="flex-1 text-center py-3 rounded-xl hover:bg-white/10 transition"
             >
-              <div className="flex h-full w-full items-center justify-center rounded-2xl bg-black text-center text-lg md:text-base transition duration-300 ease-in-out group-hover:bg-gradient-to-br group-hover:from-gray-700 group-hover:to-gray-900 font-argent px-4">
-                {label}
-              </div>
+              {label}
             </Link>
           ))}
         </div>


### PR DESCRIPTION
## Resumen
- Se integró un contenedor único de fondo negro translúcido para las opciones *Servicios* y *Automatiza* con disposición horizontal en escritorio y vertical en móvil.
- Se añadió retardo de cierre al pasar el cursor, permitiendo que los menús permanezcan visibles un par de segundos.
- Se incorporaron iconos de triángulo hacia abajo para indicar desplegables.

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689caab750e88329947d7bd1afe7dc24