### PR TITLE
Refine header layout, hero overlap, and service slider visuals

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -238,19 +238,18 @@ function Landing() {
 
         <div className="relative z-10 grid w-full grid-cols-1 md:grid-cols-2 items-center gap-8">
           {/* IZQUIERDA: titulares */}
-          <div className="md:pr-10 w-full md:w-[50vw] max-w-3xl text-left">
+          <div className="md:pr-10 w-full md:w-[50vw] max-w-3xl text-left relative top-10 md:top-0">
           <motion.h1
             initial={{ opacity: 0, y: 60 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.8 }}
             className="font-argent text-4xl md:text-7xl text-[#D6D6D6] mb-10 md:mb-16 md:ml-4 leading-tight"
           >
-            Aumenta tu <span className="font-ars text-4xl md:text-5xl">presencia digital</span>, sin trabajar de más
+            Aumenta tu <span className="font-ars text-4xl md:text-5xl font-light">presencia digital</span>, sin trabajar de más
           </motion.h1>
-
           <Link
             to="/services"
-            className="transition group mt-4 md:mt-6 flex h-12 w-44 items-center justify-center rounded-full bg-gradient-to-r from-purple-400 to-purple-700 p-[1.5px] text-white duration-300 hover:bg-gradient-to-l hover:shadow-2xl hover:shadow-purple-600/30"
+            className="transition group absolute left-0 top-[85%] md:static md:mt-6 flex h-12 w-44 items-center justify-center rounded-full bg-gradient-to-r from-purple-400 to-purple-700 p-[1.5px] text-white duration-300 hover:bg-gradient-to-l hover:shadow-2xl hover:shadow-purple-600/30"
           >
             <div className="flex h-full w-full items-center justify-center rounded-full bg-[#010207] transition duration-300 ease-in-out group-hover:bg-gradient-to-br group-hover:from-gray-700 group-hover:to-gray-900 font-argent">
               {t("hero.cta", "Descúbrelo")}

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Triangle } from 'lucide-react';
+import { ChevronDown } from 'lucide-react';
 import LanguageSelector from './LanguageSelector';
 import logo from './assets/weavionLogoBase64.js';
 
@@ -55,7 +55,7 @@ export default function Header() {
 
       {/* Menús intermedios */}
         <div className="flex-1 flex items-center justify-center">
-          <div className="glass-high rounded-2xl flex flex-col md:flex-row">
+          <div className="glass-high rounded-2xl flex flex-row">
             <DropdownMenu title={t('header.services', 'Servicios')} items={servicesItems} />
             <DropdownMenu title={t('header.automation', 'Automatiza')} items={automationItems} />
           </div>
@@ -100,10 +100,10 @@ function DropdownMenu({ title, items }) {
     >
       <button
         onClick={() => setOpen((o) => !o)}
-        className="flex w-full items-center justify-between px-6 py-3 font-argent text-white text-sm md:text-base"
+        className="flex w-full items-center justify-center gap-2 px-6 py-3 font-argent text-white text-sm md:text-base"
       >
         <span>{title}</span>
-        <Triangle className="w-3 h-3 rotate-180" />
+        <ChevronDown className="w-3 h-3" />
       </button>
       {open && (
         <div className="absolute left-1/2 -translate-x-1/2 mt-4 w-full max-w-xl md:max-w-3xl glass-high rounded-2xl flex flex-col md:flex-row gap-4 p-4 text-white">
@@ -117,6 +117,13 @@ function DropdownMenu({ title, items }) {
               {label}
             </Link>
           ))}
+          <Link
+            to="/contact"
+            onClick={() => setOpen(false)}
+            className="flex-1 text-center py-3 rounded-xl bg-purple-600 text-white hover:bg-purple-500 transition"
+          >
+            Contacto
+          </Link>
         </div>
       )}
     </div>

--- a/src/ServiciosPinnedSlider.jsx
+++ b/src/ServiciosPinnedSlider.jsx
@@ -13,19 +13,19 @@ export default function ServiciosPinnedSlider() {
       title: "Diseño & Desarrollo Web",
       desc: "Sitios ultra-rápidos y accesibles. Microinteracciones, SEO y performance 90+ en Lighthouse.",
       bg: `radial-gradient(60% 80% at 20% 20%, rgba(255,255,255,.08), rgba(0,0,0,0) 60%), linear-gradient(120deg, ${PALETTE.blackPurple}, ${PALETTE.purpleDark})`,
-      href: "/services/web",
+      href: "#/services/web",
     },
     {
       title: "Integración a ServiceTitan",
       desc: "De lead a ingreso sin fricción: captura limpia, asignación automática y control total de la operación.",
-      bg: `radial-gradient(60% 80% at 80% 30%, rgba(255,255,255,.08), rgba(0,0,0,0) 60%), linear-gradient(120deg, #21183e, ${PALETTE.purpleDark})`,
-      href: "/services/servicetitan",
+      bg: `radial-gradient(60% 80% at 80% 30%, rgba(255,255,255,.15), rgba(0,0,0,0) 60%), linear-gradient(120deg, #352a6e, ${PALETTE.purpleDark})`,
+      href: "#/services/servicetitan",
     },
     {
       title: "Analíticas de Negocio",
       desc: "Paneles en tiempo real: CAC, ROAS y revenue por canal para decidir con datos.",
-      bg: `radial-gradient(60% 80% at 20% 70%, rgba(255,255,255,.06), rgba(0,0,0,0) 60%), linear-gradient(120deg, #1a1530, #2a2146)` ,
-      href: "/services/analytics",
+      bg: `radial-gradient(60% 80% at 20% 70%, rgba(255,255,255,.12), rgba(0,0,0,0) 60%), linear-gradient(120deg, #2b2554, #43327a)` ,
+      href: "#/services/analytics",
     },
   ];
 
@@ -122,7 +122,7 @@ export default function ServiciosPinnedSlider() {
       <div style={{ maxWidth: 920, opacity: thin ? 0.0 : 1.0, transition: "opacity .15s linear", color: palette.grayLight, textAlign: "left" }}>
         <h2 style={{ margin: 0, fontWeight: 800, fontSize: "clamp(36px, 7vw, 84px)", letterSpacing: "-0.02em", background:'#F3EDFF', WebkitBackgroundClip: "text", color: "transparent", display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{item.title}</h2>
         <p style={{ marginTop: "1.1rem", fontSize: "clamp(16px, 2.1vw, 22px)", lineHeight: 1.45, display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{item.desc}</p>
-        <a href={item.href} style={{ display: "inline-flex", alignItems: "center", gap: 10, marginTop: "2rem", border: `2px solid ${palette.purpleBright}`, color: palette.purpleBright, textDecoration: "none", padding: ".9rem 1.2rem", borderRadius: 999 }}>
+        <a href={item.href} style={{ display: "inline-flex", alignItems: "center", gap: 10, marginTop: "2rem", border: `2px solid ${palette.purpleBright}`, color: '#fff', textDecoration: "none", padding: ".9rem 1.2rem", borderRadius: 999 }}>
           <span style={{ width: 10, height: 10, borderRadius: "50%", background: palette.purpleBright, display: "inline-block" }} />
           Conocer más
         </a>


### PR DESCRIPTION
## Summary
- Keep Servicios and Automatiza menus side-by-side with new chevron icons and a contact button
- Tweak hero text styling, lighten “presencia digital,” and overlap CTA on mobile
- Brighten CRM and Analytics slides, link to service pages, and make slider CTA text white

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cb27e3f1483299bc3982e826c6e5d