### PR TITLE
feat: add automation service pages and routing

### DIFF
--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -26,23 +26,19 @@ export default function Header() {
   const automationItems = [
     {
       label: t('header.automationItems.appointments', 'Genera citas'),
-      path: '/automation/genera-citas',
+      path: '/services/genera-citas',
     },
     {
-      label: t('header.automationItems.inventoryChat', 'Charla con tu inventario y modifícalo'),
-      path: '/automation/inventario-chat',
+      label: t('header.automationItems.inventory', 'Charla con tu inventario y modifícalo'),
+      path: '/services/inventario',
     },
     {
-      label: t('header.automationItems.leads', 'Captura y califica tus leads'),
-      path: '/automation/captura-califica-leads',
+      label: t('header.automationItems.quotes', 'Entrega cotizaciones inmediatas'),
+      path: '/services/cotizaciones',
     },
     {
-      label: t('header.automationItems.quotes', 'Entrega cotizaciones inmediatas y ten una postventa inteligente'),
-      path: '/automation/cotizaciones-postventa',
-    },
-    {
-      label: t('header.automationItems.contact', '¿Buscas algo más? Contáctanos'),
-      path: '/automation/contacto',
+      label: t('header.automationItems.postSale', 'Postventa inteligente'),
+      path: '/services/postventa',
     },
   ];
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "nav": {
     "about": "About Us",
     "services": "Our Services",
@@ -20,10 +20,9 @@
     "automation": "Automate",
     "automationItems": {
       "appointments": "Generate appointments",
-      "inventoryChat": "Chat with and modify your inventory",
-      "leads": "Capture and qualify your leads",
-      "quotes": "Deliver instant quotes and offer smart after-sales",
-      "contact": "Looking for something else? Contact us"
+      "inventory": "Chat with and modify your inventory",
+      "quotes": "Deliver instant quotes",
+      "postSale": "Smart post-sale"
     }
   },
   "hero": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "nav": {
     "about": "Sobre Nosotros",
     "services": "Nuestros Servicios",
@@ -20,10 +20,9 @@
     "automation": "Automatiza",
     "automationItems": {
       "appointments": "Genera citas",
-      "inventoryChat": "Charla con tu inventario y modifícalo",
-      "leads": "Captura y califica tus leads",
-      "quotes": "Entrega cotizaciones inmediatas y ten una postventa inteligente",
-      "contact": "¿Buscas algo más? Contáctanos"
+      "inventory": "Charla con tu inventario y modifícalo",
+      "quotes": "Entrega cotizaciones inmediatas",
+      "postSale": "Postventa inteligente"
     }
   },
   "hero": {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -7,11 +7,10 @@ import ContactPage from './ContactPage';
 import WebDesign from './pages/WebDesign';
 import ServiceTitan from './pages/ServiceTitan';
 import Analytics from './pages/Analytics';
-import GeneraCitas from './pages/Automatizaciones/GeneraCitas';
-import CapturaCalificaLeads from './pages/Automatizaciones/CapturaCalificaLeads';
-import InventarioChat from './pages/Automatizaciones/InventarioChat';
-import CotizacionesPostventa from './pages/Automatizaciones/CotizacionesPostventa';
-import ContactoMas from './pages/Automatizaciones/ContactoMas';
+import GeneraCitas from './pages/GeneraCitas';
+import InventarioInteractivo from './pages/InventarioInteractivo';
+import CotizacionesInmediatas from './pages/CotizacionesInmediatas';
+import PostventaInteligente from './pages/PostventaInteligente';
 import './index.css';
 import './i18n';
 import Header from './Header';
@@ -27,11 +26,10 @@ ReactDOM.createRoot(document.getElementById('root')).render(
         <Route path="services/servicetitan" element={<ServiceTitan />} />
         <Route path="services/analytics"    element={<Analytics />} />
         <Route path="contact"    element={<ContactPage />} />
-        <Route path="automation/genera-citas" element={<GeneraCitas />} />
-        <Route path="automation/captura-califica-leads" element={<CapturaCalificaLeads />} />
-        <Route path="automation/inventario-chat" element={<InventarioChat />} />
-        <Route path="automation/cotizaciones-postventa" element={<CotizacionesPostventa />} />
-        <Route path="automation/contacto" element={<ContactoMas />} />
+          <Route path="services/genera-citas" element={<GeneraCitas />} />
+          <Route path="services/inventario" element={<InventarioInteractivo />} />
+          <Route path="services/cotizaciones" element={<CotizacionesInmediatas />} />
+          <Route path="services/postventa" element={<PostventaInteligente />} />
         <Route path="*"          element={<Landing />} />  {/* fallback a landing */}
       </Routes>
     </HashRouter>

--- a/src/pages/CotizacionesInmediatas.jsx
+++ b/src/pages/CotizacionesInmediatas.jsx
@@ -1,0 +1,88 @@
+import React from 'react';
+
+/* Helpers */
+function TermHint({ term, children }) {
+  return (
+    <span className="relative group cursor-help">
+      <span className="underline decoration-[#b692ff]/80 underline-offset-2">{children}</span>
+      <span className="pointer-events-none absolute left-1/2 top-full z-30 mt-2 hidden -translate-x-1/2 whitespace-nowrap rounded-xl bg-[#0f0f16]/95 px-3 py-2 text-[12px] text-white shadow-lg ring-1 ring-white/10 backdrop-blur-md group-hover:block">
+        {term}
+      </span>
+    </span>
+  );
+}
+function QuoteTimeBars({ me=2.3, avg=19.1 }) {
+  const scale = v => Math.min(280, (v/30)*280);
+  return (
+    <svg viewBox="0 0 320 110" className="w-full h-28">
+      <defs>
+        <linearGradient id="vio" x1="0" x2="1">
+          <stop offset="0" stopColor="#b692ff" /><stop offset="1" stopColor="#7c3aed" />
+        </linearGradient>
+      </defs>
+      <text x="12" y="26" fill="#e9e7f7" fontSize="12">Tú con Weavion</text>
+      <rect x="12" y="34" width={scale(me)} height="16" rx="8" fill="url(#vio)" />
+      <text x={12+scale(me)+6} y="47" fill="#fff" fontSize="12">{me} min</text>
+
+      <text x="12" y="78" fill="#e9e7f7" fontSize="12">Promedio del sector</text>
+      <rect x="12" y="86" width={scale(avg)} height="16" rx="8" fill="#5b4c8d" />
+      <text x={12+scale(avg)+6} y="99" fill="#c9c4f0" fontSize="12">{avg} min</text>
+    </svg>
+  );
+}
+
+/* Página */
+export default function CotizacionesInmediatas() {
+  return (
+    <main className="mx-auto max-w-[1200px] px-4 py-10 space-y-8">
+      {/* HERO */}
+      <section className="rounded-2xl p-8 bg-gradient-to-b from-[#151427] to-[#0c0d16] ring-1 ring-white/10">
+        <h1 className="text-white font-extrabold text-4xl md:text-6xl leading-tight">
+          Cotiza en segundos y gana la <span className="bg-gradient-to-r from-[#b692ff] to-[#7c3aed] bg-clip-text text-transparent">ventana de decisión</span>.
+        </h1>
+        <p className="mt-3 text-[#e9e7f7] text-lg md:text-xl max-w-[75ch]">
+          Plantillas dinámicas, reglas de pricing y anexos automáticos. Envía una propuesta profesional antes que tu competencia y dispara la tasa de aceptación.
+        </p>
+      </section>
+
+      {/* PRUEBA VISUAL */}
+      <section className="grid md:grid-cols-2 gap-4">
+        <article className="rounded-2xl p-6 bg-white/[0.06] backdrop-blur-md ring-1 ring-white/10">
+          <h3 className="text-white font-bold text-xl mb-1">De la solicitud a la propuesta</h3>
+          <p className="text-[#e9e7f7]/90 mb-3">Flujo sin fricciones, con variables de precio y anexos por segmento.</p>
+          <QuoteTimeBars me={2.1} avg={18.4} />
+        </article>
+        <article className="rounded-2xl p-6 bg-white/[0.06] backdrop-blur-md ring-1 ring-white/10">
+          <h3 className="text-white font-bold text-xl mb-1">Argumentos que convierten</h3>
+          <ul className="text-[#e9e7f7] grid gap-2">
+            <li>Plantillas con tu marca y elementos de confianza (testimonios, garantías).</li>
+            <li>Reglas de precio por margen/volumen y control de descuentos.</li>
+            <li>Entrega por email/SMS/WhatsApp con tracking de apertura.</li>
+            <li>Botón de aceptación y pago (o <TermHint term="OC: Orden de compra">OC</TermHint>) en un solo paso.</li>
+          </ul>
+        </article>
+      </section>
+
+      {/* PROCESO */}
+      <section className="rounded-2xl p-6 bg-gradient-to-b from-[#171533] to-[#0b0e1a] ring-1 ring-white/10">
+        <h3 className="text-white font-bold text-2xl mb-3">Implementación en 6 pasos</h3>
+        <ol className="grid md:grid-cols-6 gap-3 text-[#e9e7f7]">
+          <li className="bg-white/5 rounded-xl p-3 ring-1 ring-white/10">Modelos de cotización.</li>
+          <li className="bg-white/5 rounded-xl p-3 ring-1 ring-white/10">Reglas de pricing.</li>
+          <li className="bg-white/5 rounded-xl p-3 ring-1 ring-white/10">Disparadores de envío.</li>
+          <li className="bg-white/5 rounded-xl p-3 ring-1 ring-white/10">Integración con pagos.</li>
+          <li className="bg-white/5 rounded-xl p-3 ring-1 ring-white/10">Tracking y alertas.</li>
+          <li className="bg-white/5 rounded-xl p-3 ring-1 ring-white/10">KPIs y mejoras.</li>
+        </ol>
+      </section>
+
+      {/* CTA */}
+      <div className="text-center">
+        <a href="#/contact" className="inline-flex items-center justify-center rounded-full px-6 py-3 text-white bg-gradient-to-r from-[#b692ff] to-[#7c3aed] shadow-md hover:shadow-lg transition">
+          Quiero cotizar ya
+        </a>
+      </div>
+    </main>
+  );
+}
+

--- a/src/pages/GeneraCitas.jsx
+++ b/src/pages/GeneraCitas.jsx
@@ -1,0 +1,149 @@
+import React from 'react';
+
+/* --- Helpers locales: TermHint + mini-charts SVG --- */
+function TermHint({ term, children }) {
+  return (
+    <span className="relative group cursor-help">
+      <span className="underline decoration-[#b692ff]/80 underline-offset-2">{children}</span>
+      <span className="pointer-events-none absolute left-1/2 top-full z-30 mt-2 hidden -translate-x-1/2 whitespace-nowrap rounded-xl bg-[#0f0f16]/95 px-3 py-2 text-[12px] text-white shadow-lg ring-1 ring-white/10 backdrop-blur-md group-hover:block">
+        {term}
+      </span>
+    </span>
+  );
+}
+function BarsAppointments({ data = [8,12,16,18,19,17,20], labels = ['L','M','X','J','V','S','D'] }) {
+  const max = Math.max(...data);
+  return (
+    <svg viewBox="0 0 260 140" className="w-full h-32">
+      <defs>
+        <linearGradient id="vio" x1="0" x2="1">
+          <stop offset="0" stopColor="#b692ff" /><stop offset="1" stopColor="#7c3aed" />
+        </linearGradient>
+      </defs>
+      {data.map((v,i)=> {
+        const h = (v/max)*92 + 6;
+        return (
+          <g key={i} transform={`translate(${20 + i*32} 18)`}>
+            <rect x="0" y={110-h} width="20" height={h} rx="8" fill="url(#vio)" />
+            <text x="10" y="126" textAnchor="middle" fontSize="10" fill="#c9c4f0">{labels[i]}</text>
+          </g>
+        )
+      })}
+    </svg>
+  );
+}
+function SLAGauge({ minutes = 3.4 }) {
+  const pct = Math.max(0, Math.min(1, 1 - minutes/10));
+  const r=56, len=Math.PI*r;
+  const dash = len*pct;
+  return (
+    <svg viewBox="0 0 140 90" className="w-full h-28">
+      <defs>
+        <linearGradient id="vio2" x1="0" x2="1">
+          <stop offset="0" stopColor="#7c3aed" /><stop offset="1" stopColor="#b692ff" />
+        </linearGradient>
+      </defs>
+      <path d="M14,70 A56,56 0 0,1 126,70" fill="none" stroke="#2a2244" strokeWidth="12" />
+      <path d="M14,70 A56,56 0 0,1 126,70" fill="none" stroke="url(#vio2)" strokeWidth="12" strokeLinecap="round" strokeDasharray={`${dash} ${len}`} />
+      <text x="70" y="58" textAnchor="middle" fontSize="12" fill="#e9e7f7">Primer contacto</text>
+      <text x="70" y="76" textAnchor="middle" fontSize="16" fontWeight="800" fill="#fff">{minutes.toFixed(1)} min</text>
+    </svg>
+  );
+}
+function SimpleFunnel({ stages = [
+  {label:'Captura', v:100},
+  {label:'Califica', v:64},
+  {label:'Agenda', v:49},
+  {label:'Cierre', v:29},
+]}) {
+  const max = stages[0].v;
+  return (
+    <svg viewBox="0 0 360 180" className="w-full h-40">
+      <defs>
+        <linearGradient id="vio" x1="0" x2="1">
+          <stop offset="0" stopColor="#b692ff" /><stop offset="1" stopColor="#7c3aed" />
+        </linearGradient>
+      </defs>
+      {stages.map((s,i)=>{
+        const w=(s.v/max)*320 + 18; const x=(360 - w)/2;
+        return (
+          <g key={i} transform={`translate(0 ${i*42})`}>
+            <rect x={x} y="14" width={w} height="30" rx="15" fill="url(#vio)" opacity={0.95 - i*0.15} />
+            <text x="18" y="34" fontSize="12" fill="#e9e7f7">{s.label}</text>
+            <text x="342" y="34" fontSize="12" fill="#c9c4f0" textAnchor="end">{s.v}%</text>
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+/* --- Página --- */
+export default function GeneraCitas() {
+  return (
+    <main className="mx-auto max-w-[1200px] px-4 py-10 space-y-8">
+      {/* HERO */}
+      <section className="rounded-2xl p-8 bg-gradient-to-b from-[#151427] to-[#0c0d16] ring-1 ring-white/10">
+        <h1 className="text-white font-extrabold text-4xl md:text-6xl leading-tight">
+          Agenda llena, <span className="bg-gradient-to-r from-[#b692ff] to-[#7c3aed] bg-clip-text text-transparent">sin perseguir a nadie</span>.
+        </h1>
+        <p className="mt-3 text-[#e9e7f7] text-lg md:text-xl max-w-[75ch]">
+          Activa reservas 24/7 con recordatorios y confirmaciones automáticas. Protege tu{" "}
+          <TermHint term="SLA: tiempo objetivo de respuesta a un nuevo contacto">SLA</TermHint>, reduce no-shows y prioriza oportunidades calientes con una experiencia de cita que se siente premium.
+        </p>
+      </section>
+
+      {/* PRUEBA VISUAL */}
+      <section className="grid md:grid-cols-3 gap-4">
+        <article className="rounded-2xl p-6 bg-white/[0.06] backdrop-blur-md ring-1 ring-white/10 md:col-span-2">
+          <h3 className="text-white font-bold text-xl mb-1">Citas por día</h3>
+          <p className="text-[#e9e7f7]/90 mb-3">Picos sanos de demanda a lo largo de la semana, sin saturar a tu equipo.</p>
+          <BarsAppointments />
+        </article>
+        <article className="rounded-2xl p-6 bg-white/[0.06] backdrop-blur-md ring-1 ring-white/10">
+          <h3 className="text-white font-bold text-xl mb-1">Primer contacto en minutos</h3>
+          <p className="text-[#e9e7f7]/90 mb-3">La velocidad multiplica la tasa de cierre; objetivo &lt; 5 min.</p>
+          <SLAGauge minutes={3.2} />
+        </article>
+      </section>
+
+      {/* VALOR + EMBUDO */}
+      <section className="grid md:grid-cols-2 gap-4">
+        <article className="rounded-2xl p-6 bg-white/[0.06] backdrop-blur-md ring-1 ring-white/10">
+          <h3 className="text-white font-bold text-xl mb-1">Embudo de agendamiento</h3>
+          <p className="text-[#e9e7f7]/90 mb-3">De la <TermHint term="Captura: formularios, landing o WhatsApp">captura</TermHint> al cierre con fugas controladas.</p>
+          <SimpleFunnel />
+        </article>
+        <article className="rounded-2xl p-6 bg-white/[0.06] backdrop-blur-md ring-1 ring-white/10">
+          <h3 className="text-white font-bold text-xl mb-1">Beneficios que verás</h3>
+          <ul className="text-[#e9e7f7] grid gap-2">
+            <li>Widget de reservas con disponibilidad real y bloqueo de huecos.</li>
+            <li>Recordatorios por email/SMS/WhatsApp (menos no-shows).</li>
+            <li>Asignación por zona/agenda y confirmación con 1 clic.</li>
+            <li>Reporte semanal: citas generadas, asistencia y motivos de cancelación.</li>
+          </ul>
+        </article>
+      </section>
+
+      {/* PROCESO */}
+      <section className="rounded-2xl p-6 bg-gradient-to-b from-[#171533] to-[#0b0e1a] ring-1 ring-white/10">
+        <h3 className="text-white font-bold text-2xl mb-3">Implementación en 5 días</h3>
+        <ol className="grid md:grid-cols-5 gap-3 text-[#e9e7f7]">
+          <li className="bg-white/5 rounded-xl p-3 ring-1 ring-white/10">Diagnóstico de flujos y canales.</li>
+          <li className="bg-white/5 rounded-xl p-3 ring-1 ring-white/10">Configuración de agenda y reglas.</li>
+          <li className="bg-white/5 rounded-xl p-3 ring-1 ring-white/10">Automatizaciones y recordatorios.</li>
+          <li className="bg-white/5 rounded-xl p-3 ring-1 ring-white/10">Embeds y pruebas en sitio.</li>
+          <li className="bg-white/5 rounded-xl p-3 ring-1 ring-white/10">Reporte inicial y ajuste fino.</li>
+        </ol>
+      </section>
+
+      {/* CTA */}
+      <div className="text-center">
+        <a href="#/contact" className="inline-flex items-center justify-center rounded-full px-6 py-3 text-white bg-gradient-to-r from-[#b692ff] to-[#7c3aed] shadow-md hover:shadow-lg transition">
+          Quiero llenar mi agenda
+        </a>
+      </div>
+    </main>
+  );
+}
+

--- a/src/pages/InventarioInteractivo.jsx
+++ b/src/pages/InventarioInteractivo.jsx
@@ -1,0 +1,134 @@
+import React from 'react';
+
+/* Helpers locales */
+function TermHint({ term, children }) {
+  return (
+    <span className="relative group cursor-help">
+      <span className="underline decoration-[#b692ff]/80 underline-offset-2">{children}</span>
+      <span className="pointer-events-none absolute left-1/2 top-full z-30 mt-2 hidden -translate-x-1/2 whitespace-nowrap rounded-xl bg-[#0f0f16]/95 px-3 py-2 text-[12px] text-white shadow-lg ring-1 ring-white/10 backdrop-blur-md group-hover:block">
+        {term}
+      </span>
+    </span>
+  );
+}
+function InventoryChatSVG() {
+  return (
+    <svg viewBox="0 0 360 160" className="w-full h-40">
+      <defs>
+        <linearGradient id="vio" x1="0" x2="1">
+          <stop offset="0" stopColor="#b692ff" /><stop offset="1" stopColor="#7c3aed" />
+        </linearGradient>
+      </defs>
+      <rect x="12" y="16" width="336" height="90" rx="14" fill="none" stroke="url(#vio)" strokeWidth="2.5"/>
+      <rect x="24" y="30" width="90" height="18" rx="9" fill="#b692ff" opacity=".28"/>
+      <rect x="120" y="30" width="140" height="18" rx="9" fill="#b692ff" opacity=".18"/>
+      <rect x="24" y="56" width="200" height="16" rx="8" fill="#b692ff" opacity=".22"/>
+      <g transform="translate(290 95)">
+        <circle r="14" fill="none" stroke="url(#vio)" strokeWidth="2.5"/>
+        <circle r="3" fill="#fff"/>
+        <path d="M0-10v4M0 10v-4M-10 0h4M10 0h-4M-7-7l2 2M7 7l-2-2M-7 7l2-2M7-7l-2 2" stroke="#a98cff" strokeWidth="1.8" strokeLinecap="round"/>
+      </g>
+    </svg>
+  );
+}
+function TurnoverBars({ months=['Ene','Feb','Mar','Abr','May','Jun'], data=[3.1,3.4,3.8,4.2,4.4,4.7] }) {
+  const max = Math.max(...data);
+  return (
+    <svg viewBox="0 0 320 140" className="w-full h-32">
+      <defs>
+        <linearGradient id="vio2" x1="0" x2="1">
+          <stop offset="0" stopColor="#7c3aed" /><stop offset="1" stopColor="#b692ff" />
+        </linearGradient>
+      </defs>
+      {data.map((v,i)=>{
+        const h=(v/max)*96 + 6;
+        return (
+          <g key={i} transform={`translate(${22 + i*44} 18)`}>
+            <rect x="0" y={110-h} width="26" height={h} rx="10" fill="url(#vio2)" />
+            <text x="13" y="126" textAnchor="middle" fontSize="10" fill="#c9c4f0">{months[i]}</text>
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+function AccuracyLinear({ pct=98 }) {
+  const w = Math.max(0, Math.min(100, pct));
+  return (
+    <svg viewBox="0 0 340 40" className="w-full h-10">
+      <defs>
+        <linearGradient id="vio3" x1="0" x2="1">
+          <stop offset="0" stopColor="#b692ff" /><stop offset="1" stopColor="#7c3aed" />
+        </linearGradient>
+      </defs>
+      <rect x="10" y="12" width="320" height="12" rx="6" fill="#2a2244"/>
+      <rect x="10" y="12" width={(w/100)*320} height="12" rx="6" fill="url(#vio3)"/>
+      <text x="330" y="30" textAnchor="end" fill="#fff" fontSize="12" fontWeight="700">{w}%</text>
+    </svg>
+  );
+}
+
+/* Página */
+export default function InventarioInteractivo() {
+  return (
+    <main className="mx-auto max-w-[1200px] px-4 py-10 space-y-8">
+      {/* HERO */}
+      <section className="rounded-2xl p-8 bg-gradient-to-b from-[#151427] to-[#0c0d16] ring-1 ring-white/10">
+        <h1 className="text-white font-extrabold text-4xl md:text-6xl leading-tight">
+          Tu inventario responde <span className="bg-gradient-to-r from-[#b692ff] to-[#7c3aed] bg-clip-text text-transparent">en tiempo real</span>.
+        </h1>
+        <p className="mt-3 text-[#e9e7f7] text-lg md:text-xl max-w-[75ch]">
+          Consulta stock, costos y tiempos en segundos. Cambia precios o disponibilidad desde un chat interno; se refleja al instante en la web y en tu <TermHint term="CRM: sistema donde viven contactos, oportunidades y ventas">CRM</TermHint>.
+        </p>
+      </section>
+
+      {/* VISUAL + KPIs */}
+      <section className="grid md:grid-cols-2 gap-4">
+        <article className="rounded-2xl p-6 bg-white/[0.06] backdrop-blur-md ring-1 ring-white/10">
+          <h3 className="text-white font-bold text-xl mb-1">Chat con acciones</h3>
+          <p className="text-[#e9e7f7]/90 mb-3">Consulta, edita y confirma cambios con trazabilidad por usuario.</p>
+          <InventoryChatSVG />
+        </article>
+        <article className="rounded-2xl p-6 bg-white/[0.06] backdrop-blur-md ring-1 ring-white/10">
+          <h3 className="text-white font-bold text-xl mb-1">Exactitud y rotación</h3>
+          <p className="text-[#e9e7f7]/90 mb-2">Objetivo: exactitud &gt; 97% y rotación creciente sin quiebres.</p>
+          <AccuracyLinear pct={98} />
+          <div className="mt-3">
+            <TurnoverBars />
+          </div>
+        </article>
+      </section>
+
+      {/* BENEFICIOS */}
+      <section className="rounded-2xl p-6 bg-white/[0.06] backdrop-blur-md ring-1 ring-white/10">
+        <h3 className="text-white font-bold text-2xl mb-3">Beneficios operativos</h3>
+        <ul className="grid md:grid-cols-2 gap-3 text-[#e9e7f7]">
+          <li className="bg-white/5 rounded-xl p-3 ring-1 ring-white/10">Edición masiva de precios, stock y lotes con aprobación.</li>
+          <li className="bg-white/5 rounded-xl p-3 ring-1 ring-white/10">Sincronización automática con web y marketplace.</li>
+          <li className="bg-white/5 rounded-xl p-3 ring-1 ring-white/10">Alertas por <TermHint term="Stockout: quedarte sin inventario vendible">stockout</TermHint> y sobre-inventario.</li>
+          <li className="bg-white/5 rounded-xl p-3 ring-1 ring-white/10">Historial y bitácora por usuario (auditoría simple).</li>
+        </ul>
+      </section>
+
+      {/* PROCESO */}
+      <section className="rounded-2xl p-6 bg-gradient-to-b from-[#171533] to-[#0b0e1a] ring-1 ring-white/10">
+        <h3 className="text-white font-bold text-2xl mb-3">Implementación guiada</h3>
+        <ol className="grid md:grid-cols-5 gap-3 text-[#e9e7f7]">
+          <li className="bg-white/5 rounded-xl p-3 ring-1 ring-white/10">Mapeo de SKUs y fuentes.</li>
+          <li className="bg-white/5 rounded-xl p-3 ring-1 ring-white/10">Reglas de sincronización.</li>
+          <li className="bg-white/5 rounded-xl p-3 ring-1 ring-white/10">Roles y aprobaciones.</li>
+          <li className="bg-white/5 rounded-xl p-3 ring-1 ring-white/10">Capacitación al equipo.</li>
+          <li className="bg-white/5 rounded-xl p-3 ring-1 ring-white/10">KPIs y alertas activas.</li>
+        </ol>
+      </section>
+
+      {/* CTA */}
+      <div className="text-center">
+        <a href="#/contact" className="inline-flex items-center justify-center rounded-full px-6 py-3 text-white bg-gradient-to-r from-[#b692ff] to-[#7c3aed] shadow-md hover:shadow-lg transition">
+          Quiero dominar mi inventario
+        </a>
+      </div>
+    </main>
+  );
+}
+

--- a/src/pages/PostventaInteligente.jsx
+++ b/src/pages/PostventaInteligente.jsx
@@ -1,0 +1,117 @@
+import React from 'react';
+
+/* Helpers */
+function TermHint({ term, children }) {
+  return (
+    <span className="relative group cursor-help">
+      <span className="underline decoration-[#b692ff]/80 underline-offset-2">{children}</span>
+      <span className="pointer-events-none absolute left-1/2 top-full z-30 mt-2 hidden -translate-x-1/2 whitespace-nowrap rounded-xl bg-[#0f0f16]/95 px-3 py-2 text-[12px] text-white shadow-lg ring-1 ring-white/10 backdrop-blur-md group-hover:block">
+        {term}
+      </span>
+    </span>
+  );
+}
+function SmileGauge({ score=82, label="CSAT" }) {
+  const pct = Math.max(0, Math.min(100, score)) / 100;
+  const r=50, len=Math.PI*r; const dash=len*pct;
+  return (
+    <svg viewBox="0 0 140 90" className="w-full h-28">
+      <defs>
+        <linearGradient id="vio" x1="0" x2="1">
+          <stop offset="0" stopColor="#b692ff" /><stop offset="1" stopColor="#7c3aed" />
+        </linearGradient>
+      </defs>
+      <path d="M14,70 A50,50 0 0,1 126,70" fill="none" stroke="#2a2244" strokeWidth="10" />
+      <path d="M14,70 A50,50 0 0,1 126,70" fill="none" stroke="url(#vio)" strokeWidth="10" strokeLinecap="round"
+            strokeDasharray={`${dash} ${len}`} />
+      <text x="70" y="58" textAnchor="middle" fontSize="12" fill="#e9e7f7">{label}</text>
+      <text x="70" y="76" textAnchor="middle" fontSize="16" fontWeight="800" fill="#fff">{score}</text>
+    </svg>
+  );
+}
+function LinearRetention({ months=['M1','M2','M3','M4','M5','M6'], pct=[100,92,89,87,85,84] }) {
+  const maxW = 300;
+  return (
+    <svg viewBox="0 0 340 120" className="w-full h-28">
+      <defs>
+        <linearGradient id="vio2" x1="0" x2="1">
+          <stop offset="0" stopColor="#7c3aed" /><stop offset="1" stopColor="#b692ff" />
+        </linearGradient>
+      </defs>
+      {pct.map((v,i)=>{
+        const w=(v/100)*maxW;
+        return (
+          <g key={i} transform={`translate(12 ${18 + i*16})`}>
+            <text x="0" y="10" fontSize="10" fill="#c9c4f0">{months[i]}</text>
+            <rect x="28" y="2" width={maxW} height="10" rx="5" fill="#2a2244"/>
+            <rect x="28" y="2" width={w} height="10" rx="5" fill="url(#vio2)"/>
+            <text x="332" y="10" fontSize="10" fill="#e9e7f7" textAnchor="end">{v}%</text>
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+/* Página */
+export default function PostventaInteligente() {
+  return (
+    <main className="mx-auto max-w-[1200px] px-4 py-10 space-y-8">
+      {/* HERO */}
+      <section className="rounded-2xl p-8 bg-gradient-to-b from-[#151427] to-[#0c0d16] ring-1 ring-white/10">
+        <h1 className="text-white font-extrabold text-4xl md:text-6xl leading-tight">
+          Postventa que convierte <span className="bg-gradient-to-r from-[#b692ff] to-[#7c3aed] bg-clip-text text-transparent">clientes de por vida</span>.
+        </h1>
+        <p className="mt-3 text-[#e9e7f7] text-lg md:text-xl max-w-[75ch]">
+          Seguimiento automático, encuestas y tickets proactivos. Aumenta tu{" "}
+          <TermHint term="LTV: valor de vida del cliente en toda su relación con tu marca">LTV</TermHint> mientras reduces el churn con experiencias memorables después de la compra.
+        </p>
+      </section>
+
+      {/* KPIs */}
+      <section className="grid md:grid-cols-3 gap-4">
+        <article className="rounded-2xl p-6 bg-white/[0.06] backdrop-blur-md ring-1 ring-white/10">
+          <h3 className="text-white font-bold text-xl mb-1">Satisfacción</h3>
+          <p className="text-[#e9e7f7]/90 mb-3">Encuestas automáticas por canal (CSAT/NPS).</p>
+          <SmileGauge score={84} label="CSAT" />
+        </article>
+        <article className="rounded-2xl p-6 bg-white/[0.06] backdrop-blur-md ring-1 ring-white/10 md:col-span-2">
+          <h3 className="text-white font-bold text-xl mb-1">Retención a 6 meses</h3>
+          <p className="text-[#e9e7f7]/90 mb-3">Flujos de renovación y programas de mantenimiento.</p>
+          <LinearRetention />
+        </article>
+      </section>
+
+      {/* QUÉ SE AUTOMATIZA */}
+      <section className="rounded-2xl p-6 bg-white/[0.06] backdrop-blur-md ring-1 ring-white/10">
+        <h3 className="text-white font-bold text-2xl mb-3">Qué se automatiza</h3>
+        <ul className="grid md:grid-cols-2 gap-3 text-[#e9e7f7]">
+          <li className="bg-white/5 rounded-xl p-3 ring-1 ring-white/10">Recordatorios de mantenimiento y renovaciones.</li>
+          <li className="bg-white/5 rounded-xl p-3 ring-1 ring-white/10">Encuestas post-servicio y creación automática de tickets si hay alerta.</li>
+          <li className="bg-white/5 rounded-xl p-3 ring-1 ring-white/10">Upsells relevantes por historial y comportamiento.</li>
+          <li className="bg-white/5 rounded-xl p-3 ring-1 ring-white/10">Reportes ejecutivos semanales para accionar rápido.</li>
+        </ul>
+      </section>
+
+      {/* PROCESO */}
+      <section className="rounded-2xl p-6 bg-gradient-to-b from-[#171533] to-[#0b0e1a] ring-1 ring-white/10">
+        <h3 className="text-white font-bold text-2xl mb-3">Despliegue en 5 pasos</h3>
+        <ol className="grid md:grid-cols-5 gap-3 text-[#e9e7f7]">
+          <li className="bg-white/5 rounded-xl p-3 ring-1 ring-white/10">Mapa de puntos de contacto.</li>
+          <li className="bg-white/5 rounded-xl p-3 ring-1 ring-white/10">Diseño de flujos y plantillas.</li>
+          <li className="bg-white/5 rounded-xl p-3 ring-1 ring-white/10">Integraciones con CRM y canales.</li>
+          <li className="bg-white/5 rounded-xl p-3 ring-1 ring-white/10">Pruebas end-to-end.</li>
+          <li className="bg-white/5 rounded-xl p-3 ring-1 ring-white/10">KPIs y optimización.</li>
+        </ol>
+      </section>
+
+      {/* CTA */}
+      <div className="text-center">
+        <a href="#/contact" className="inline-flex items-center justify-center rounded-full px-6 py-3 text-white bg-gradient-to-r from-[#b692ff] to-[#7c3aed] shadow-md hover:shadow-lg transition">
+          Quiero mejorar mi postventa
+        </a>
+      </div>
+    </main>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add standalone pages for appointments, inventory chat, instant quotes, and smart post-sale
- wire automation menu to new `/services/*` routes
- update i18n strings for automation menu

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cb2cb35188329bfd438d50dbd8b8e