### PR TITLE
Refine Why our services section and remove redundant block

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -293,9 +293,7 @@ export default function App() {
         <div className="h-12 md:h-24" />
 
         {/* Stats Section */}
-        <section className="py-24 px-4 bg-black rounded-xl overflow-hidden">
-          <StatsSection />
-        </section>
+        <StatsSection />
 
         {/* Spacer */}
         <div className="h-12 md:h-24" />
@@ -318,14 +316,6 @@ export default function App() {
 
         {/* Spacer */}
         <div className="h-12 md:h-24" />
-
-        {/* Sección: Por qué nosotros? */}
-        <section className="py-24 px-4 bg-black rounded-xl overflow-hidden">
-          <h2 className="text-3xl md:text-4xl font-bold text-white mb-8 text-center">
-            ¿Por qué nosotros?
-          </h2>
-          {/* Contenido adicional aquí */}
-        </section>
       </div>
     </>
   );

--- a/src/StatsSection.jsx
+++ b/src/StatsSection.jsx
@@ -27,13 +27,13 @@ export default function StatsSection() {
     <section
       id="why-us"
       ref={sectionRef}
-      className="min-h-screen flex flex-col items-center justify-center px-4"
+      className="py-24 px-4 bg-black rounded-xl overflow-hidden flex flex-col items-center justify-center"
     >
       <h2 className="stat-title stat-animate text-4xl md:text-6xl font-bold mb-16 text-center">
         {t('whyus.title', '¿Por qué nuestros servicios?')}
       </h2>
       <div className="stats-container grid grid-cols-1 md:grid-cols-2 gap-8 w-full max-w-4xl">
-        <div className="stat-item stat-animate gradient-border rounded-3xl">
+        <div className="stat-item stat-animate gradient-border rounded-3xl overflow-hidden">
           <div className="flex flex-col items-center p-8 rounded-3xl bg-black">
             <span className="number font-bold text-7xl md:text-9xl mb-4 inline-block">
               {t('whyus.stat1.number', '20 %')}
@@ -43,7 +43,7 @@ export default function StatsSection() {
             </p>
           </div>
         </div>
-        <div className="stat-item stat-animate gradient-border rounded-3xl">
+        <div className="stat-item stat-animate gradient-border rounded-3xl overflow-hidden">
           <div className="flex flex-col items-center p-8 rounded-3xl bg-black">
             <span className="number font-bold text-7xl md:text-9xl mb-4 inline-block">
               {t('whyus.stat2.number', '42 %')}


### PR DESCRIPTION
## Summary
- Round backgrounds within the "Why our services?" statistics section and handle its own styling
- Remove trailing "¿Por qué nosotros?" block from the page

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ccbccdca88329984d6a452625080c