### PR TITLE
Localize service and automation links

### DIFF
--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -11,34 +11,34 @@ export default function Header() {
   const servicesItems = [
     {
       label: t('header.servicesItems.webDev', 'Diseño y Desarrollo web'),
-      path: '/services/web',
+      path: t('routes.services.web', '/services/web'),
     },
     {
       label: t('header.servicesItems.crm', 'Integración a CRM o Service Titan'),
-      path: '/services/crm',
+      path: t('routes.services.crm', '/services/crm-servicetitan'),
     },
     {
       label: t('header.servicesItems.analytics', 'Analíticas de negocio'),
-      path: '/services/analiticas',
+      path: t('routes.services.analytics', '/services/analiticas-negocio'),
     },
   ];
 
   const automationItems = [
     {
       label: t('header.automationItems.appointments', 'Genera citas'),
-      path: '/services/genera-citas',
+      path: t('routes.automation.appointments', '/services/genera-citas'),
     },
     {
       label: t('header.automationItems.inventory', 'Charla con tu inventario y modifícalo'),
-      path: '/services/inventario',
+      path: t('routes.automation.inventory', '/services/inventario'),
     },
     {
       label: t('header.automationItems.quotes', 'Entrega cotizaciones inmediatas'),
-      path: '/services/cotizaciones',
+      path: t('routes.automation.quotes', '/services/cotizaciones'),
     },
     {
       label: t('header.automationItems.postSale', 'Postventa inteligente'),
-      path: '/services/postventa',
+      path: t('routes.automation.postSale', '/services/postventa'),
     },
   ];
 

--- a/src/ServiciosPinnedSlider.jsx
+++ b/src/ServiciosPinnedSlider.jsx
@@ -15,19 +15,19 @@ export default function ServiciosPinnedSlider() {
       title: t('servicesSlider.items.web.title', 'Diseño & Desarrollo Web'),
       desc: t('servicesSlider.items.web.desc', 'Sitios ultra-rápidos y accesibles. Microinteracciones, SEO y performance 90+ en Lighthouse.'),
       bg: `radial-gradient(60% 80% at 20% 20%, rgba(255,255,255,.08), rgba(0,0,0,0) 60%), linear-gradient(120deg, ${PALETTE.blackPurple}, ${PALETTE.purpleDark})`,
-      href: "#/services/web",
+      href: `#${t('routes.services.web', '/services/web')}`,
     },
     {
       title: t('servicesSlider.items.servicetitan.title', 'Integración a ServiceTitan'),
       desc: t('servicesSlider.items.servicetitan.desc', 'De lead a ingreso sin fricción: captura limpia, asignación automática y control total de la operación.'),
       bg: `radial-gradient(60% 80% at 80% 30%, rgba(255,255,255,.15), rgba(0,0,0,0) 60%), linear-gradient(120deg, #352a6e, ${PALETTE.purpleDark})`,
-      href: "#/services/crm-servicetitan",
+      href: `#${t('routes.services.crm', '/services/crm-servicetitan')}`,
     },
     {
       title: t('servicesSlider.items.analytics.title', 'Analíticas de Negocio'),
       desc: t('servicesSlider.items.analytics.desc', 'Paneles en tiempo real: CAC, ROAS y revenue por canal para decidir con datos.'),
       bg: `radial-gradient(60% 80% at 20% 70%, rgba(255,255,255,.12), rgba(0,0,0,0) 60%), linear-gradient(120deg, #2b2554, #43327a)` ,
-      href: "#/services/analiticas-negocio",
+      href: `#${t('routes.services.analytics', '/services/analiticas-negocio')}`,
     },
   ];
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -25,6 +25,19 @@
       "postSale": "Smart post-sale"
     }
   },
+  "routes": {
+    "services": {
+      "web": "/services/web",
+      "crm": "/services/crm-servicetitan",
+      "analytics": "/services/business-analytics"
+    },
+    "automation": {
+      "appointments": "/services/generate-appointments",
+      "inventory": "/services/inventory",
+      "quotes": "/services/instant-quotes",
+      "postSale": "/services/smart-post-sale"
+    }
+  },
   "hero": {
     "title": "Boost your business with web solutions orbiting innovation and security.",
     "subtitle": "Your business deserves a stellar online presence. We'll help you reach for the stars.",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -25,6 +25,19 @@
       "postSale": "Postventa inteligente"
     }
   },
+  "routes": {
+    "services": {
+      "web": "/services/web",
+      "crm": "/services/crm-servicetitan",
+      "analytics": "/services/analiticas-negocio"
+    },
+    "automation": {
+      "appointments": "/services/genera-citas",
+      "inventory": "/services/inventario",
+      "quotes": "/services/cotizaciones",
+      "postSale": "/services/postventa"
+    }
+  },
   "hero": {
     "title": "Impulsa tu empresa con soluciones web orbitadas en innovación y seguridad.",
     "subtitle": "Tu negocio merece una presencia estelar en línea. Te ayudaremos a alcanzar las estrellas.",

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -24,12 +24,17 @@ ReactDOM.createRoot(document.getElementById('root')).render(
         <Route path="services"   element={<ServiciosPinnedSlider />} />
         <Route path="services/web"          element={<WebDesign />} />
         <Route path="services/crm-servicetitan" element={<CRMServiceTitan />} />
-        <Route path="services/analiticas-negocio"    element={<AnaliticasNegocio />} />
+        <Route path="services/analiticas-negocio" element={<AnaliticasNegocio />} />
+        <Route path="services/business-analytics" element={<AnaliticasNegocio />} />
         <Route path="contact"    element={<ContactPage />} />
           <Route path="services/genera-citas" element={<GeneraCitas />} />
+          <Route path="services/generate-appointments" element={<GeneraCitas />} />
           <Route path="services/inventario" element={<InventarioInteractivo />} />
+          <Route path="services/inventory" element={<InventarioInteractivo />} />
           <Route path="services/cotizaciones" element={<CotizacionesInmediatas />} />
+          <Route path="services/instant-quotes" element={<CotizacionesInmediatas />} />
           <Route path="services/postventa" element={<PostventaInteligente />} />
+          <Route path="services/smart-post-sale" element={<PostventaInteligente />} />
         <Route path="*"          element={<Landing />} />  {/* fallback a landing */}
       </Routes>
     </HashRouter>


### PR DESCRIPTION
## Summary
- Translate service and automation routes and wire components to use them
- Update service slider and header dropdown to respect current language
- Support English slugs in router

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ce3364b9c83298008be50835d36f9