### PR TITLE
Improve branding and contact sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,11 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <!-- Use relative paths so assets resolve correctly on GitHub Pages -->
-    <link rel="icon" type="image/svg+xml" href="./src/assets/logo-rounded.svg" />
+    <link rel="icon" type="image/png" href="./src/assets/logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#0C0D13" />
     <meta name="description" content="Weavion - Desarrollo web y diseño de experiencias digitales" />
-    <link rel="apple-touch-icon" href="./src/assets/logo-rounded.svg" />
+    <link rel="apple-touch-icon" href="./src/assets/logo.png" />
     <link rel="manifest" href="./manifest.json" />
     <title>Weavion</title>
 

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -43,7 +43,7 @@ export default function Header() {
   ];
 
   return (
-      <div className="fixed top-4 inset-x-0 z-50 flex items-center px-4 md:px-8 drop-shadow-[0_4px_8px_rgba(0,0,0,0.4)]">
+    <div className="fixed top-4 inset-x-0 z-50 flex items-center px-4 md:px-8 drop-shadow-[0_8px_20px_rgba(0,0,0,0.8)]">
       {/* Logo izquierda */}
         <Link to="/" className="mr-4 md:mr-8">
           <div className="w-14 h-14 rounded-full overflow-hidden">

--- a/src/components/ProductInterestSection.jsx
+++ b/src/components/ProductInterestSection.jsx
@@ -6,10 +6,10 @@ export default function ProductInterestSection() {
   const { t } = useTranslation();
   const products = ['web', 'analytics', 'servicetitan', 'automation'];
   return (
-    <section className="mt-16">
+    <section className="mt-16 text-center">
       <h2 className="text-2xl font-bold mb-4">{t('products.interestTitle')}</h2>
       <p className="mb-6">{t('products.interestSubtitle')}</p>
-      <div className="grid md:grid-cols-2 gap-4">
+      <div className="grid md:grid-cols-2 gap-4 text-left">
         {products.map((key) => (
           <div key={key} className="p-4 rounded-lg bg-white/10 text-white">
             <h3 className="font-semibold">{t(`products.${key}.title`)}</h3>
@@ -17,10 +17,10 @@ export default function ProductInterestSection() {
           </div>
         ))}
       </div>
-      <div className="mt-6">
+      <div className="mt-6 text-center">
         <Link
           to="/contact"
-          className="inline-block px-6 py-3 rounded-full bg-purple-600 hover:bg-purple-500 text-white font-semibold"
+          className="inline-block px-8 py-4 rounded-full bg-purple-600 hover:bg-purple-500 text-white font-semibold text-lg"
         >
           {t('products.contact')}
         </Link>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -159,18 +159,6 @@
       "detail": "We create automated email marketing campaigns that build loyalty and boost conversions, integrated with your sales tools."
     }
   },
-  "product": {
-    "prompt": "This is your product. Let's see how our agency can transform it."
-  },
-  "products": {
-    "interestTitle": "Interested in another product?",
-    "interestSubtitle": "Discover the advantages of our other solutions:",
-    "web": {"title": "Websites", "desc": "Modern, optimized designs."},
-    "analytics": {"title": "Analytics", "desc": "Data-driven decisions."},
-    "servicetitan": {"title": "ServiceTitan", "desc": "Frictionless integrated operation."},
-    "automation": {"title": "Automation", "desc": "Efficient automated processes."},
-    "contact": "Contact us for details."
-  },
   "common": {
     "discover": "Discover it",
     "backHome": "Back to home",
@@ -202,6 +190,27 @@
         "desc": "Flows that work for you: reminders, inventory and more."
       }
     }
+  },
+  "products": {
+    "interestTitle": "You may also be interested",
+    "interestSubtitle": "Explore more of our solutions",
+    "web": {
+      "title": "Web Design & Development",
+      "desc": "Fast, accessible sites that convert."
+    },
+    "analytics": {
+      "title": "Business Analytics",
+      "desc": "Real-time data to decide with confidence."
+    },
+    "servicetitan": {
+      "title": "ServiceTitan Integration",
+      "desc": "From lead to revenue with full control."
+    },
+    "automation": {
+      "title": "Automations",
+      "desc": "Workflows that run for you all day."
+    },
+    "contact": "Contact us"
   },
   "pages": {
     "web": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -158,18 +158,6 @@
       "detail": "Diseñamos campañas de email marketing automatizadas que fidelizan y convierten, integradas con tus herramientas de ventas."
     }
   },
-  "product": {
-    "prompt": "Este es tu producto. Veamos cómo lo puede transformar nuestra agencia."
-  },
-  "products": {
-    "interestTitle": "¿Interesado en otro producto?",
-    "interestSubtitle": "Descubre las ventajas de nuestras otras soluciones:",
-    "web": {"title": "Sitios web", "desc": "Diseños modernos y optimizados."},
-    "analytics": {"title": "Analíticas", "desc": "Decisiones basadas en datos."},
-    "servicetitan": {"title": "ServiceTitan", "desc": "Operación integrada sin fricción."},
-    "automation": {"title": "Automatización", "desc": "Procesos eficientes y automáticos."},
-    "contact": "Contáctanos para más detalles."
-  },
   "common": {
     "discover": "Descúbrelo",
     "backHome": "Volver al inicio",
@@ -181,13 +169,13 @@
     "title": "Weavion",
     "description": "Weavion - Desarrollo web y diseño de experiencias digitales"
   },
-  "servicesSlider": {
-    "learnMore": "Conocer más",
-    "items": {
-      "web": {
-        "title": "Diseño & Desarrollo Web",
-        "desc": "Sitios ultra-rápidos y accesibles. Microinteracciones, SEO y performance 90+ en Lighthouse."
-      },
+    "servicesSlider": {
+      "learnMore": "Conocer más",
+      "items": {
+        "web": {
+          "title": "Diseño & Desarrollo Web",
+          "desc": "Sitios ultra-rápidos y accesibles. Microinteracciones, SEO y performance 90+ en Lighthouse."
+        },
       "servicetitan": {
         "title": "Integración a ServiceTitan",
         "desc": "De lead a ingreso sin fricción: captura limpia, asignación automática y control total de la operación."
@@ -200,12 +188,33 @@
         "title": "Automatizaciones",
         "desc": "Flujos que trabajan por ti: recordatorios, inventario y más."
       }
-    }
-  },
-  "pages": {
-    "web": {
-      "hero": {
-        "title": "Sitios web que convierten visitas en ventas",
+      }
+    },
+    "products": {
+      "interestTitle": "También te puede interesar",
+      "interestSubtitle": "Explora más de nuestras soluciones",
+      "web": {
+        "title": "Diseño & Desarrollo Web",
+        "desc": "Sitios rápidos y accesibles que convierten."
+      },
+      "analytics": {
+        "title": "Analíticas de Negocio",
+        "desc": "Datos en tiempo real para decidir con confianza."
+      },
+      "servicetitan": {
+        "title": "Integración a ServiceTitan",
+        "desc": "De lead a ingreso sin fricción y control total."
+      },
+      "automation": {
+        "title": "Automatizaciones",
+        "desc": "Flujos que trabajan por ti todo el día."
+      },
+      "contact": "Quiero saber más"
+    },
+    "pages": {
+      "web": {
+        "hero": {
+          "title": "Sitios web que convierten visitas en ventas",
         "subtitle": "Rendimiento real, <TermHint>Optimización para buscadores: estructura, contenido y performance que elevan ranking y tráfico orgánico.</TermHint> técnico y UX enfocada en acción. Tu marca luce premium y cada pantalla empuja a “comprar”, “agendar” o “pedir cotización”.",
         "term": "SEO"
       },

--- a/src/pages/AnaliticasNegocio.jsx
+++ b/src/pages/AnaliticasNegocio.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import ProductInterestSection from "../components/ProductInterestSection";
 
 /* Tooltip */
 function TermHint({ term, children }) {
@@ -153,9 +154,9 @@ export default function AnaliticasNegocio() {
           <li>Alertas (caída de conversión, picos de CAC, baja de retención).</li>
           <li>Playbook de decisiones para priorizar inversión y esfuerzos.</li>
         </ul>
-      </section>
-
-    </main>
-  );
-}
+        </section>
+        <ProductInterestSection />
+      </main>
+    );
+  }
 

--- a/src/pages/CRMServiceTitan.jsx
+++ b/src/pages/CRMServiceTitan.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import ProductInterestSection from "../components/ProductInterestSection";
 
 /* Tooltip sencillo: término subrayado + globo al hover */
 function TermHint({ term, children }) {
@@ -182,8 +183,9 @@ export default function CRMServiceTitan() {
           <li>Panel de salud (API, jobs, sincronizaciones y alertas).</li>
           <li>Playbook de operación comercial + capacitación.</li>
         </ul>
-      </section>
-    </main>
-  );
-}
+        </section>
+        <ProductInterestSection />
+      </main>
+    );
+  }
 


### PR DESCRIPTION
## Summary
- use uploaded logo.png for browser and touch icons
- add heavier shadow to navbar
- center and enlarge product contact CTA with translations
- show contact CTA on service detail pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d139eaf9083298577b7710a85e023