### PR TITLE
Round 'Why Us' boxes and translate process heading

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -269,6 +269,8 @@ function Landing() {
    App principal
 ------------------------------------------------------- */
 export default function App() {
+  const { t } = useTranslation();
+
   return (
     <>
       <BackgroundLayers />
@@ -301,7 +303,7 @@ export default function App() {
         {/* Process Section */}
         <section className="py-24 px-4 bg-black rounded-xl overflow-hidden">
           <h2 className="text-3xl md:text-4xl font-bold text-white mb-8 text-center">
-            ¿Cómo funciona nuestro proceso?
+            {t('process.title', '¿Cómo funciona nuestro proceso?')}
           </h2>
           <ProcessTimeline />
         </section>

--- a/src/index.css
+++ b/src/index.css
@@ -488,6 +488,7 @@ spline-viewer canvas#spline {
 .gradient-border {
   border: 2px solid transparent;
   border-image: linear-gradient(to bottom right, #6b21a8, #6f47ff, #8b00ff) 1;
+  border-radius: 1.5rem;
 }
 
 @keyframes pulse-glow {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -86,7 +86,7 @@
     }
   },
   "process": {
-    "title": "How does our work process work?",
+    "title": "How does our process work?",
     "step1": "Initial Meeting",
     "step1Detail": "We get to know your business, objectives, and requirements. Together we define the scope and roadmap of the project.",
     "step2": "Research & Planning",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -86,7 +86,7 @@
     }
   },
   "process": {
-    "title": "¿Cómo es nuestro proceso de trabajo?",
+    "title": "¿Cómo funciona nuestro proceso?",
     "step1": "Reunión Inicial",
     "step1Detail": "Conocemos tu negocio, objetivos y requisitos. Juntos definimos el alcance y hoja de ruta del proyecto.",
     "step2": "Investigación y Planificación",


### PR DESCRIPTION
## Summary
- round "Why our services" stat boxes with gradient-border radius
- translate "How does our process work?" heading via i18n

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d16302acc832988279d0a56d9c065