### PR TITLE
refactor: modern dropdown menus for services and automation

### DIFF
--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -104,15 +104,19 @@ function DropdownMenu({ title, items }) {
         <ChevronDown className="w-3 h-3" />
       </button>
       {open && (
-        <div className="absolute left-1/2 -translate-x-1/2 mt-4 w-full max-w-xl md:max-w-3xl glass-high rounded-2xl flex flex-col md:flex-row gap-4 p-4 text-white">
+        <div className="absolute left-1/2 -translate-x-1/2 mt-2 w-64 rounded-xl bg-black/40 backdrop-blur-lg border border-white/10 shadow-[0_8px_30px_rgba(0,0,0,0.3)] overflow-hidden">
           {items.map(({ label, path }, idx) => (
             <Link
               key={idx}
               to={path}
               onClick={() => setOpen(false)}
-              className="flex-1 text-center py-3 rounded-xl hover:bg-white/10 transition"
+              className="group relative block w-full px-5 py-3 text-left text-white/80 transition-all duration-300 hover:text-white border-t border-white/10 first:border-t-0"
             >
-              {label}
+              <span className="absolute left-0 top-0 h-full w-0 bg-purple-400 transition-all duration-300 group-hover:w-1"></span>
+              <span className="absolute inset-0 bg-gradient-to-r from-purple-700/30 to-purple-400/30 bg-[length:200%_100%] bg-left transition-all duration-500 group-hover:bg-right opacity-0 group-hover:opacity-100"></span>
+              <span className="relative z-10 block transition-transform duration-300 group-hover:translate-x-1">
+                {label}
+              </span>
             </Link>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- redesign dropdown container with glassmorphism and shadow
- add animated gradient and side indicator on hover

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d169a82488329a137949bf03a3801