### PR TITLE
feat: ajustar fuente vertical en slider de servicios

### DIFF
--- a/src/ServiciosPinnedSlider.jsx
+++ b/src/ServiciosPinnedSlider.jsx
@@ -175,12 +175,12 @@ export default function ServiciosPinnedSlider() {
               alignItems: "center",
               justifyContent: "center",
               textAlign: "center",
-              fontSize: "clamp(20px, 8vh, 48px)",
+              fontSize: "clamp(16px, 6vh, 40px)",
               letterSpacing: "0.1em",
               color: "#fff",
               opacity: 0.75,
               padding: "1rem 0",
-              fontFamily: "'argent-pixel-cf', sans-serif",
+              fontFamily: "var(--font-display)",
               overflow: "hidden",
             }}
             aria-hidden


### PR DESCRIPTION
## Summary
- use display font variable for vertical slider text
- reduce vertical slider text size to better align with service subsections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d3eca94d083298b49c94d6bb81e9f