### PR TITLE
style: update language selector gradient

### DIFF
--- a/src/LanguageSelector.jsx
+++ b/src/LanguageSelector.jsx
@@ -27,7 +27,7 @@ export default function LanguageSelector() {
   return (
     <button
       onClick={toggleLanguage}
-      className="cursor-pointer h-10 w-20 text-center text-white text-lg font-bold bg-gradient-to-r from-purple-500 via-pink-500 to-purple-500 p-[2px] rounded-full hover:bg-gradient-to-l hover:shadow-2xl hover:shadow-purple-600/30"
+      className="cursor-pointer h-10 w-20 text-center text-white text-lg font-bold bg-gradient-to-r from-purple-800 via-purple-400 to-purple-800 p-[2px] rounded-full hover:bg-gradient-to-l hover:shadow-2xl hover:shadow-purple-600/30"
     >
       {i18n.language.toUpperCase()}
     </button>


### PR DESCRIPTION
## Summary
- refine language selector gradient to feature darker purple edges and a lighter purple center

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d3f96145c83299043a894e746ab7b