### PR TITLE
feat: apply Lo-Res 21 OT Serif to landing title

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -244,9 +244,9 @@ function Landing() {
             initial={{ opacity: 0, y: 60 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.8 }}
-            className="font-argent text-4xl md:text-7xl text-[#D6D6D6] mb-10 md:mb-16 md:ml-[200px] leading-tight"
+            className="font-lores text-4xl md:text-7xl text-[#D6D6D6] mb-10 md:mb-16 md:ml-[200px] leading-tight"
           >
-            Aumenta tu <span className="font-ars text-4xl md:text-5xl font-light">presencia digital</span>, sin trabajar de más
+            Aumenta tu <span className="text-4xl md:text-5xl">presencia digital</span>, sin trabajar de más
           </motion.h1>
           <Link
             to="/services"

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,4 @@
+@import url("https://use.typekit.net/dyf0yaq.css");
 @import url('https://fonts.cdnfonts.com/css/arial-nova');
 @import url('https://fonts.cdnfonts.com/css/argent-pixel-cf');
 
@@ -250,6 +251,12 @@ spline-viewer canvas#spline {
   font-family: 'argent-pixel-cf', sans-serif;
   font-weight: 400;
   font-style: italic;
+}
+
+.font-lores {
+  font-family: "lores-21-serif", sans-serif;
+  font-weight: 400;
+  font-style: normal;
 }
 
 .font-clean {


### PR DESCRIPTION
## Summary
- import Lo-Res 21 OT Serif font and define helper class
- use Lo-Res font for landing page headline

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d4939430083298dddbec88fb9dec6