### PR TITLE
Ensure services navigation opens at top and add CRM contact section

### DIFF
--- a/src/ScrollToTop.jsx
+++ b/src/ScrollToTop.jsx
@@ -1,0 +1,10 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+  return null;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { HashRouter, Routes, Route } from 'react-router-dom';
+import ScrollToTop from './ScrollToTop';
 import Landing from './App';
 import ServiciosPinnedSlider from './ServiciosPinnedSlider';
 import ContactPage from './ContactPage';
@@ -18,6 +19,7 @@ import Header from './Header';
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <HashRouter>
+      <ScrollToTop />
       <Header />
       <Routes>
         <Route path=""           element={<Landing />} />

--- a/src/pages/CRMServiceTitan.jsx
+++ b/src/pages/CRMServiceTitan.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ProductInterestSection from "../components/ProductInterestSection";
+import ContactSection from "../ContactSection";
 
 /* Tooltip sencillo: término subrayado + globo al hover */
 function TermHint({ term, children }) {
@@ -185,6 +186,7 @@ export default function CRMServiceTitan() {
         </ul>
         </section>
         <ProductInterestSection />
+        <ContactSection />
       </main>
     );
   }


### PR DESCRIPTION
## Summary
- reset scroll position on each route change
- append contact section to CRM ServiceTitan page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d47f13cc8832983cb5d8e23072135