### PR TITLE
feat: improve language selector and hero spacing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,7 @@
 // src/App.jsx
 import React, { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
-import { useTranslation } from "react-i18next";
+import { useTranslation, Trans } from "react-i18next";
 import { motion } from "framer-motion";
 import { ArrowLeft, ArrowRight } from "lucide-react";
 
@@ -246,11 +246,14 @@ function Landing() {
             transition={{ duration: 0.8 }}
             className="font-argent text-4xl md:text-7xl text-[#D6D6D6] mb-10 md:mb-16 md:ml-[200px] leading-tight"
           >
-            Aumenta tu <span className="font-ars text-4xl md:text-5xl font-light">presencia digital</span>, sin trabajar de más
+            <Trans
+              i18nKey="hero.headline"
+              components={[<span className="font-ars text-4xl md:text-5xl font-light" />]}
+            />
           </motion.h1>
           <Link
             to="/services"
-            className="transition group absolute left-0 top-[85%] md:static md:mt-10 md:ml-[200px] flex h-12 w-44 items-center justify-center rounded-full bg-gradient-to-r from-purple-400 to-purple-700 p-[1.5px] text-white duration-300 hover:bg-gradient-to-l hover:shadow-2xl hover:shadow-purple-600/30"
+            className="transition group absolute left-0 top-[90%] md:static md:mt-20 md:ml-[200px] flex h-12 w-44 items-center justify-center rounded-full bg-gradient-to-r from-purple-400 to-purple-700 p-[1.5px] text-white duration-300 hover:bg-gradient-to-l hover:shadow-2xl hover:shadow-purple-600/30"
           >
             <div className="flex h-full w-full items-center justify-center rounded-full bg-[#010207] transition duration-300 ease-in-out group-hover:bg-gradient-to-br group-hover:from-gray-700 group-hover:to-gray-900 font-argent">
               {t("hero.cta", "Descúbrelo")}

--- a/src/LanguageSelector.jsx
+++ b/src/LanguageSelector.jsx
@@ -27,7 +27,7 @@ export default function LanguageSelector() {
   return (
     <button
       onClick={toggleLanguage}
-      className="cursor-pointer h-10 w-20 text-center text-white text-lg font-bold bg-gradient-to-r from-purple-800 via-purple-400 to-purple-800 p-[2px] rounded-full hover:bg-gradient-to-l hover:shadow-2xl hover:shadow-purple-600/30"
+      className="cursor-pointer h-10 w-20 text-center text-white text-lg font-bold bg-gradient-to-r from-purple-900 via-purple-600 to-purple-900 p-[2px] rounded-full hover:bg-gradient-to-l hover:shadow-2xl hover:shadow-purple-700/30"
     >
       {i18n.language.toUpperCase()}
     </button>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -42,7 +42,8 @@
     "title": "Boost your business with web solutions orbiting innovation and security.",
     "subtitle": "Your business deserves a stellar online presence. We'll help you reach for the stars.",
     "motivational": "The universe of digital possibilities awaits your brand",
-    "cta": "Discover how"
+    "cta": "Discover how",
+    "headline": "Boost your <0>digital presence</0>, without working harder"
   },
   "services": {
     "title": "What do you gain with us?",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -42,7 +42,8 @@
     "title": "Impulsa tu empresa con soluciones web orbitadas en innovación y seguridad.",
     "subtitle": "Tu negocio merece una presencia estelar en línea. Te ayudaremos a alcanzar las estrellas.",
     "motivational": "El universo de posibilidades digitales espera tu marca",
-    "cta": "Descubre cómo"
+    "cta": "Descubre cómo",
+    "headline": "Aumenta tu <0>presencia digital</0>, sin trabajar de más"
   },
   "services": {
     "title": "¿Qué ganas con nosotros?",


### PR DESCRIPTION
## Summary
- tweak language selector gradient for richer purple hues
- translate hero headline and increase spacing above call-to-action

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d479160d48329aea50b3e5c0408c6