### PR TITLE
feat: apply TechMenu to dropdown selectors

### DIFF
--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { ChevronDown } from 'lucide-react';
 import LanguageSelector from './LanguageSelector';
 import logo from './assets/logo.png';
+import TechMenu from './TechMenu';
 
 export default function Header() {
   const { t, i18n } = useTranslation();
@@ -13,14 +14,17 @@ export default function Header() {
   const servicesItems = useMemo(
     () => [
       {
+        id: 'web',
         label: t('header.servicesItems.webDev'),
         path: t('routes.services.web'),
       },
       {
+        id: 'crm',
         label: t('header.servicesItems.crm'),
         path: t('routes.services.crm'),
       },
       {
+        id: 'analytics',
         label: t('header.servicesItems.analytics'),
         path: t('routes.services.analytics'),
       },
@@ -31,18 +35,22 @@ export default function Header() {
   const automationItems = useMemo(
     () => [
       {
+        id: 'appointments',
         label: t('header.automationItems.appointments'),
         path: t('routes.automation.appointments'),
       },
       {
+        id: 'inventory',
         label: t('header.automationItems.inventory'),
         path: t('routes.automation.inventory'),
       },
       {
+        id: 'quotes',
         label: t('header.automationItems.quotes'),
         path: t('routes.automation.quotes'),
       },
       {
+        id: 'postSale',
         label: t('header.automationItems.postSale'),
         path: t('routes.automation.postSale'),
       },
@@ -125,21 +133,8 @@ function DropdownMenu({ id, title, items, openMenu, setOpenMenu }) {
         <ChevronDown className="w-3 h-3" />
       </button>
       {open && (
-        <div className="absolute left-1/2 -translate-x-1/2 mt-2 w-64 rounded-xl bg-black/40 backdrop-blur-lg border border-white/10 shadow-[0_8px_30px_rgba(0,0,0,0.3)] overflow-hidden">
-          {items.map(({ label, path }, idx) => (
-            <Link
-              key={idx}
-              to={path}
-              onClick={() => setOpenMenu(null)}
-              className="group relative block w-full px-5 py-3 text-left text-white/80 transition-all duration-300 hover:text-white border-t border-white/10 first:border-t-0"
-            >
-              <span className="absolute left-0 top-0 h-full w-0 bg-purple-400 transition-all duration-300 group-hover:w-1"></span>
-              <span className="absolute inset-0 bg-gradient-to-r from-purple-700/30 to-purple-400/30 bg-[length:200%_100%] bg-left transition-all duration-500 group-hover:bg-right opacity-0 group-hover:opacity-100"></span>
-              <span className="relative z-10 block transition-transform duration-300 group-hover:translate-x-1">
-                {label}
-              </span>
-            </Link>
-          ))}
+        <div className="absolute left-1/2 -translate-x-1/2 mt-2">
+          <TechMenu items={items} onSelect={() => setOpenMenu(null)} className="w-[360px]" />
         </div>
       )}
     </div>

--- a/src/TechMenu.jsx
+++ b/src/TechMenu.jsx
@@ -1,0 +1,72 @@
+import React, { useState, useRef } from "react";
+import { motion } from "framer-motion";
+import { Link } from "react-router-dom";
+
+export default function TechMenu({ items, onSelect, className = "" }) {
+  const [active, setActive] = useState(items[0]?.id);
+  const [mouse, setMouse] = useState({ x: 0, y: 0 });
+  const cardRef = useRef(null);
+
+  const handleMove = (e) => {
+    const r = cardRef.current?.getBoundingClientRect();
+    if (!r) return;
+    setMouse({ x: e.clientX - r.left, y: e.clientY - r.top });
+  };
+
+  return (
+    <div
+      ref={cardRef}
+      onMouseMove={handleMove}
+      className={`relative rounded-2xl p-[2px] bg-gradient-to-r from-purple-500 via-fuchsia-500 to-cyan-400 ${className}`}
+      role="menu"
+      aria-label="Services"
+    >
+      {/* Glass background + spotlight */}
+      <div
+        className="relative rounded-2xl bg-black/70 backdrop-blur-md overflow-hidden"
+        style={{
+          maskImage: `radial-gradient(220px 220px at ${mouse.x}px ${mouse.y}px, #000 35%, transparent 65%)`,
+          WebkitMaskImage: `radial-gradient(220px 220px at ${mouse.x}px ${mouse.y}px, #000 35%, transparent 65%)`,
+        }}
+      >
+        {/* Sutil grid decorativa */}
+        <div className="pointer-events-none absolute inset-0 opacity-[0.07] [background-image:linear-gradient(to_right,white_1px,transparent_1px),linear-gradient(to_bottom,white_1px,transparent_1px)] [background-size:24px_24px]"></div>
+
+        {/* Lista */}
+        <ul className="relative">
+          {/* Pastilla animada detrás del activo */}
+          <motion.div
+            layout
+            className="absolute left-2 right-2 h-[56px] rounded-xl bg-gradient-to-r from-purple-600/30 to-fuchsia-600/20 border border-white/10"
+            transition={{ type: "spring", stiffness: 420, damping: 34 }}
+            style={{
+              top: 8 + items.findIndex((i) => i.id === active) * (56 + 8),
+            }}
+          />
+          {items.map((item, idx) => (
+            <li key={item.id} className={idx > 0 ? "border-t border-white/10" : ""}>
+              <Link
+                role="menuitemradio"
+                aria-checked={active === item.id}
+                to={item.path}
+                onClick={() => {
+                  setActive(item.id);
+                  onSelect?.(item.id);
+                }}
+                className="relative z-10 w-full text-left px-4 py-3.5 rounded-xl outline-none focus-visible:ring-2 focus-visible:ring-fuchsia-400/60 hover:bg-white/2 transition"
+              >
+                <div className="text-[15px] font-medium text-white/90">
+                  {item.label}
+                </div>
+                {item.desc && (
+                  <div className="text-xs text-white/60 mt-0.5">{item.desc}</div>
+                )}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add reusable TechMenu component with gradient spotlight design
- update header menus to use TechMenu and keep menus mutually exclusive

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d4713fc088329af699a7051fb8d6b