### PR TITLE
feat: apply gradient rounded style to stats

### DIFF
--- a/src/StatsSection.jsx
+++ b/src/StatsSection.jsx
@@ -33,8 +33,8 @@ export default function StatsSection() {
         {t('whyus.title', '¿Por qué nuestros servicios?')}
       </h2>
       <div className="stats-container grid grid-cols-1 md:grid-cols-2 gap-8 w-full max-w-4xl">
-        <div className="stat-item stat-animate gradient-border rounded-3xl overflow-hidden">
-          <div className="flex flex-col items-center p-8 rounded-3xl bg-black">
+        <div className="stat-item stat-animate rounded-2xl p-[2px] bg-gradient-to-br from-[#6b21a8] via-[#6f47ff] to-[#8b00ff]">
+          <div className="flex flex-col items-center p-6 rounded-2xl bg-black">
             <span className="number font-bold text-7xl md:text-9xl mb-4 inline-block">
               {t('whyus.stat1.number', '20 %')}
             </span>
@@ -43,8 +43,8 @@ export default function StatsSection() {
             </p>
           </div>
         </div>
-        <div className="stat-item stat-animate gradient-border rounded-3xl overflow-hidden">
-          <div className="flex flex-col items-center p-8 rounded-3xl bg-black">
+        <div className="stat-item stat-animate rounded-2xl p-[2px] bg-gradient-to-br from-[#6b21a8] via-[#6f47ff] to-[#8b00ff]">
+          <div className="flex flex-col items-center p-6 rounded-2xl bg-black">
             <span className="number font-bold text-7xl md:text-9xl mb-4 inline-block">
               {t('whyus.stat2.number', '42 %')}
             </span>


### PR DESCRIPTION
## Summary
- replace custom gradient-border with Tailwind gradient wrappers in "Why our services" stats
- round inner blocks and apply black background for contrast

## Testing
- `npx -y vitest run`


------
https://chatgpt.com/codex/tasks/task_e_689d468292648329abbcadbf51bd14f7