### PR TITLE
refactor: merge mobile menus and resize logo

### DIFF
--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -58,34 +58,51 @@ export default function Header() {
     [i18n.language, t]
   );
 
+  const allItems = useMemo(
+    () => [...servicesItems, ...automationItems],
+    [servicesItems, automationItems]
+  );
+
   return (
     <div className="fixed top-4 inset-x-0 z-50 flex items-center px-4 md:px-8 drop-shadow-[0_8px_20px_rgba(0,0,0,0.8)]">
       {/* Logo izquierda */}
         <Link to="/" className="mr-4 md:mr-8">
-          <div className="w-14 h-14 rounded-full overflow-hidden">
+          <div className="w-10 h-10 md:w-14 md:h-14 rounded-full overflow-hidden">
             <img src={logo} alt="Weavion logo" className="w-full h-full object-cover" />
           </div>
         </Link>
 
       {/* Menús intermedios */}
         <div className="flex-1 flex items-center justify-center">
-          <div className="glass-high rounded-2xl flex flex-row">
-            <DropdownMenu
-              id="services"
-              title={t('header.services', 'Servicios')}
-              items={servicesItems}
-              defaultPath="/services"
-              openMenu={openMenu}
-              setOpenMenu={setOpenMenu}
-            />
-            <DropdownMenu
-              id="automation"
-              title={t('header.automation', 'Automatiza')}
-              items={automationItems}
-              defaultPath={automationItems[0]?.path}
-              openMenu={openMenu}
-              setOpenMenu={setOpenMenu}
-            />
+          <div className="glass-high rounded-2xl flex">
+            <div className="hidden md:flex flex-row">
+              <DropdownMenu
+                id="services"
+                title={t('header.services', 'Servicios')}
+                items={servicesItems}
+                defaultPath="/services"
+                openMenu={openMenu}
+                setOpenMenu={setOpenMenu}
+              />
+              <DropdownMenu
+                id="automation"
+                title={t('header.automation', 'Automatiza')}
+                items={automationItems}
+                defaultPath={automationItems[0]?.path}
+                openMenu={openMenu}
+                setOpenMenu={setOpenMenu}
+              />
+            </div>
+            <div className="md:hidden flex">
+              <DropdownMenu
+                id="all"
+                title={t('header.services', 'Servicios')}
+                items={allItems}
+                defaultPath={servicesItems[0]?.path}
+                openMenu={openMenu}
+                setOpenMenu={setOpenMenu}
+              />
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- shrink mobile logo for a more compact header
- combine Services and Automate menus into a single mobile dropdown

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d56bd2b488329982c324694e7e20c