### PR TITLE
fix: translate hero and services heading

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -246,7 +246,7 @@ function Landing() {
             transition={{ duration: 0.8 }}
             className="font-lores text-5xl md:text-8xl text-[#D6D6D6] mb-10 md:mb-16 md:ml-[200px] leading-tight"
           >
-            Aumenta tu <span className="text-purple-400">presencia digital</span>, sin trabajar de más
+            <Trans i18nKey="hero.headline" components={{ 0: <span className="text-purple-400" /> }} />
           </motion.h1>
           <Link
             to="/services"
@@ -280,10 +280,10 @@ export default function App() {
 
         {/* Services intro */}
         <section className="py-24 px-4 text-center">
-          <h2 className="text-4xl md:text-6xl font-extrabold text-white">Nuestros servicios</h2>
+          <h2 className="text-4xl md:text-6xl font-extrabold text-white">{t("nav.services")}</h2>
           <p className="mt-4 text-lg text-gray-300 flex items-center justify-center gap-2">
             <ArrowLeft className="w-5 h-5" />
-            Mueve hacia los lados para explorar cada panel
+            {t("services.sliderInstruction")}
             <ArrowRight className="w-5 h-5" />
           </p>
         </section>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -48,7 +48,8 @@
   "services": {
     "title": "What do you gain with us?",
     "subtitle": "Digital Solutions for your business",
-    "description": "We offer core services that cover all your business digital needs. Click on the cards to see more details."
+    "description": "We offer core services that cover all your business digital needs. Click on the cards to see more details.",
+    "sliderInstruction": "Move sideways to explore each panel"
   },
   "about": {
     "title": "About Us",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -48,7 +48,8 @@
   "services": {
     "title": "¿Qué ganas con nosotros?",
     "subtitle": "Soluciones Digitales para tu empresa",
-    "description": "Ofrecemos servicios principales que cubren todas las necesidades digitales de tu empresa. Haz clic en las tarjetas para ver más detalles."
+    "description": "Ofrecemos servicios principales que cubren todas las necesidades digitales de tu empresa. Haz clic en las tarjetas para ver más detalles.",
+    "sliderInstruction": "Mueve hacia los lados para explorar cada panel"
   },
   "about": {
     "title": "Sobre Nosotros",


### PR DESCRIPTION
## Summary
- use i18n for hero headline
- localize services heading and slider instruction

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d5721e5c08329a51e782802374f8e