### PR TITLE
fix: open services and automation menus without redirect

### DIFF
--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -74,7 +74,6 @@ export default function Header() {
               id="services"
               title={t('header.services', 'Servicios')}
               items={servicesItems}
-              defaultPath="/services"
               openMenu={openMenu}
               setOpenMenu={setOpenMenu}
             />
@@ -82,7 +81,6 @@ export default function Header() {
               id="automation"
               title={t('header.automation', 'Automatiza')}
               items={automationItems}
-              defaultPath={automationItems[0]?.path}
               openMenu={openMenu}
               setOpenMenu={setOpenMenu}
             />
@@ -95,7 +93,7 @@ export default function Header() {
   );
 }
 
-function DropdownMenu({ id, title, items, defaultPath, openMenu, setOpenMenu }) {
+function DropdownMenu({ id, title, items, openMenu, setOpenMenu }) {
   const menuRef = useRef(null);
   const closeTimer = useRef();
 
@@ -127,14 +125,14 @@ function DropdownMenu({ id, title, items, defaultPath, openMenu, setOpenMenu }) 
       onMouseEnter={handleEnter}
       onMouseLeave={handleLeave}
     >
-        <Link
-          to={defaultPath}
+        <button
+          type="button"
           onClick={() => setOpenMenu(open ? null : id)}
           className="flex w-full items-center justify-center gap-2 px-6 py-3 font-argent text-white text-sm md:text-base"
         >
           <span>{title}</span>
           <ChevronDown className="w-3 h-3" />
-        </Link>
+        </button>
       {open && (
         <div className="absolute left-1/2 -translate-x-1/2 mt-2">
           <TechMenu items={items} onSelect={() => setOpenMenu(null)} />


### PR DESCRIPTION
## Summary
- stop top-level Services and Automate links from redirecting
- keep navigation for individual menu items

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d56ea4f2083298ae44f950b56a776