### PR TITLE
Refine contact form checkbox styling

### DIFF
--- a/src/ContactForm.jsx
+++ b/src/ContactForm.jsx
@@ -64,7 +64,7 @@ export default function ContactForm() {
         <span className="block mb-2 text-white">
           {t('contact.serviceLabel')}
         </span>
-        <div className="flex flex-col gap-2 text-white">
+        <div className="flex flex-col gap-1 text-white">
           {serviceOptions.map((opt, idx) => (
             <label key={opt.value} className="custom-checkbox text-white">
               <input

--- a/src/index.css
+++ b/src/index.css
@@ -283,7 +283,7 @@ spline-viewer canvas#spline {
   align-items: center;
   cursor: pointer;
   user-select: none;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0;
 }
 
 .custom-checkbox input {
@@ -296,24 +296,24 @@ spline-viewer canvas#spline {
 
 .custom-checkbox .checkmark {
   position: relative;
-  height: 24px;
-  width: 24px;
-  min-width: 24px;
+  height: 20px;
+  width: 20px;
+  min-width: 20px;
   margin-right: 0.5rem;
   border-radius: 6px;
   background-color: var(--color-gunmetal);
-  border: 2px solid var(--color-accent);
+  border: 2px solid #9333ea;
   box-sizing: border-box;
   transition: all 0.2s ease;
 }
 
 .custom-checkbox:hover .checkmark {
-  background-color: rgba(111, 71, 255, 0.1);
+  background-color: rgba(147, 51, 234, 0.1);
 }
 
 .custom-checkbox input:checked + .checkmark {
-  background-color: var(--color-accent);
-  border-color: var(--color-highlight);
+  background-color: #9333ea;
+  border-color: #c084fc;
 }
 
 .custom-checkbox .checkmark::after {


### PR DESCRIPTION
## Summary
- reduce vertical spacing between contact form service options
- shrink and recolor custom checkbox for a purple theme

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d63e8144c8329b20909dff0d4e3d3