### PR TITLE
Add divider separating Services and Automation items in mobile menu

### DIFF
--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -101,6 +101,7 @@ export default function Header() {
                 defaultPath={servicesItems[0]?.path}
                 openMenu={openMenu}
                 setOpenMenu={setOpenMenu}
+                dividerIndex={servicesItems.length}
               />
             </div>
           </div>
@@ -112,7 +113,7 @@ export default function Header() {
   );
 }
 
-function DropdownMenu({ id, title, items, openMenu, setOpenMenu }) {
+function DropdownMenu({ id, title, items, openMenu, setOpenMenu, dividerIndex }) {
   const menuRef = useRef(null);
   const closeTimer = useRef();
 
@@ -154,7 +155,11 @@ function DropdownMenu({ id, title, items, openMenu, setOpenMenu }) {
         </button>
       {open && (
         <div className="absolute left-1/2 -translate-x-1/2 mt-2">
-          <TechMenu items={items} onSelect={() => setOpenMenu(null)} />
+          <TechMenu
+            items={items}
+            onSelect={() => setOpenMenu(null)}
+            dividerIndex={dividerIndex}
+          />
         </div>
       )}
     </div>

--- a/src/TechMenu.jsx
+++ b/src/TechMenu.jsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 
 // Dropdown menu used in the header for Services and Automate sections.
 // It features a subtle purple gradient border and a dark glassy background.
-export default function TechMenu({ items, onSelect, className = "" }) {
+export default function TechMenu({ items, onSelect, className = "", dividerIndex }) {
   return (
     <div
       className={`rounded-xl p-[1.5px] bg-gradient-to-r from-purple-600 to-purple-400 w-64 ${className}`}
@@ -12,16 +12,20 @@ export default function TechMenu({ items, onSelect, className = "" }) {
     >
       <div className="rounded-xl bg-black/80 backdrop-blur-sm py-2">
         {items.map((item, idx) => (
-          <Link
-            key={item.id}
-            to={item.path}
-            onClick={() => onSelect?.(item.id)}
-            className={`block px-4 py-2 ${
-              idx === 0 ? "text-white" : "text-gray-300"
-            } hover:bg-purple-500/20 transition rounded-md`}
-          >
-            {item.label}
-          </Link>
+          <React.Fragment key={item.id}>
+            <Link
+              to={item.path}
+              onClick={() => onSelect?.(item.id)}
+              className={`block px-4 py-2 ${
+                idx === 0 ? "text-white" : "text-gray-300"
+              } hover:bg-purple-500/20 transition rounded-md`}
+            >
+              {item.label}
+            </Link>
+            {dividerIndex === idx + 1 && (
+              <div className="my-2 border-t border-white/10" />
+            )}
+          </React.Fragment>
         ))}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- enable optional divider in TechMenu
- distinguish Services and Automation in mobile dropdown via divider

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d6466328c8329b38337879653ec66