### PR TITLE
feat: improve service section navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,6 @@
 // src/App.jsx
 // src/App.jsx
 import React, { useEffect, useRef, useState } from "react";
-import { Link } from "react-router-dom";
 import { useTranslation, Trans } from "react-i18next";
 import { motion } from "framer-motion";
 import { ArrowLeft, ArrowRight } from "lucide-react";
@@ -248,15 +247,20 @@ function Landing() {
           >
             <Trans i18nKey="hero.headline" components={{ 0: <span className="text-purple-300" /> }} />
           </motion.h1>
-          <Link
-            to="/services"
-            className="transition group absolute left-0 top-[110%] z-50 md:static md:mt-20 md:ml-[200px] flex h-14 w-48 md:h-20 md:w-64 items-center justify-center rounded-full bg-gradient-to-r from-purple-400 to-purple-700 p-[1.5px] text-white duration-300 hover:bg-gradient-to-l hover:shadow-2xl hover:shadow-purple-600/30"
-          >
-            <div className="flex h-full w-full items-center justify-center rounded-full bg-[#010207] transition duration-300 ease-in-out group-hover:bg-gradient-to-br group-hover:from-gray-700 group-hover:to-gray-900 font-argent">
-              {t("hero.cta", "Descúbrelo")}
-            </div>
-          </Link>
-        </div>
+            <button
+              onClick={() => {
+                const el = document.getElementById('services-section');
+                if (el) {
+                  el.scrollIntoView({ behavior: 'smooth' });
+                }
+              }}
+              className="transition group absolute left-0 top-[110%] z-50 md:static md:mt-20 md:ml-[200px] flex h-14 w-48 md:h-20 md:w-64 items-center justify-center rounded-full bg-gradient-to-r from-purple-400 to-purple-700 p-[1.5px] text-white duration-300 hover:bg-gradient-to-l hover:shadow-2xl hover:shadow-purple-600/30"
+            >
+              <div className="flex h-full w-full items-center justify-center rounded-full bg-[#010207] transition duration-300 ease-in-out group-hover:bg-gradient-to-br group-hover:from-gray-700 group-hover:to-gray-900 font-argent">
+                {t("hero.cta", "Descúbrelo")}
+              </div>
+            </button>
+          </div>
 
         {/* DERECHA: modelo 3D (altura controlada) */}
         <SplineViewerBox className="w-full h-[500px] md:h-[700px] rounded-xl overflow-hidden bg-black/60 mx-auto z-10" />
@@ -273,13 +277,18 @@ export default function App() {
 
   return (
     <>
-      <BackgroundLayers />
-      <CursorStars />
-      <div className="relative z-10">
-        <Landing />
+        <BackgroundLayers />
+        <CursorStars />
+        <div className="relative z-10">
+          <Landing />
 
-        {/* Services intro */}
-        <section className="py-24 px-4 text-center">
+          {/* Separator */}
+          <div className="w-full flex justify-center my-12">
+            <div className="w-full max-w-4xl h-px bg-gradient-to-r from-transparent via-gray-700 to-transparent" />
+          </div>
+
+          {/* Services intro */}
+          <section id="services-section" className="py-24 px-4 text-center">
           <h2 className="text-4xl md:text-6xl font-extrabold text-white">{t("nav.services")}</h2>
           <p className="mt-4 text-lg text-gray-300 flex items-center justify-center gap-2">
             <ArrowLeft className="w-5 h-5" />

--- a/src/ServiciosPinnedSlider.jsx
+++ b/src/ServiciosPinnedSlider.jsx
@@ -60,6 +60,8 @@ export default function ServiciosPinnedSlider() {
   useEffect(() => {
     const el = sectionRef.current;
     if (!el) return;
+    let startX = 0;
+    let startY = 0;
     const handleWheel = (e) => {
       if (Math.abs(e.deltaX) <= Math.abs(e.deltaY)) return;
       e.preventDefault();
@@ -70,8 +72,34 @@ export default function ServiciosPinnedSlider() {
       const raw = scrollX.current / Math.max(1, maxScroll);
       setProgress(raw);
     };
+    const onTouchStart = (e) => {
+      if (e.touches.length !== 1) return;
+      startX = e.touches[0].clientX;
+      startY = e.touches[0].clientY;
+    };
+    const onTouchMove = (e) => {
+      if (e.touches.length !== 1) return;
+      const dx = startX - e.touches[0].clientX;
+      const dy = startY - e.touches[0].clientY;
+      if (Math.abs(dx) <= Math.abs(dy)) return;
+      e.preventDefault();
+      const perPanel = dims.vw * SLOW_FACTOR;
+      const totalWidth = dims.vw + (items.length - 1) * perPanel;
+      const maxScroll = totalWidth - dims.vw;
+      scrollX.current = clamp(scrollX.current + dx, 0, maxScroll);
+      const raw = scrollX.current / Math.max(1, maxScroll);
+      setProgress(raw);
+      startX = e.touches[0].clientX;
+      startY = e.touches[0].clientY;
+    };
     el.addEventListener("wheel", handleWheel, { passive: false });
-    return () => el.removeEventListener("wheel", handleWheel);
+    el.addEventListener("touchstart", onTouchStart, { passive: false });
+    el.addEventListener("touchmove", onTouchMove, { passive: false });
+    return () => {
+      el.removeEventListener("wheel", handleWheel);
+      el.removeEventListener("touchstart", onTouchStart);
+      el.removeEventListener("touchmove", onTouchMove);
+    };
   }, [dims]);
 
   // Derivar estado: cuál panel está activo y cuánto llevamos de su transición


### PR DESCRIPTION
## Summary
- smooth scroll to services when clicking the hero button
- add visual separator before the services section
- enable touch swipe for services slider on mobile

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_689dc782c6508329852fe6d197f29023