### PR TITLE
Style: make contact form checkboxes purple and thinner

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -302,7 +302,7 @@ spline-viewer canvas#spline {
   margin-right: 0.5rem;
   border-radius: 6px;
   background-color: var(--color-gunmetal);
-  border: 2px solid var(--color-accent);
+  border: 1.5px solid #7C3AED;
   box-sizing: border-box;
   transition: all 0.2s ease;
 }
@@ -312,8 +312,8 @@ spline-viewer canvas#spline {
 }
 
 .custom-checkbox input:checked + .checkmark {
-  background-color: var(--color-accent);
-  border-color: var(--color-highlight);
+  background-color: #7C3AED;
+  border-color: #7C3AED;
 }
 
 .custom-checkbox .checkmark::after {


### PR DESCRIPTION
## Summary
- set thinner, medium-purple borders for contact form checkboxes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dc810b804832980e957e0862d77d5