### PR TITLE
Fix services links and mobile automation section

### DIFF
--- a/src/ContactForm.jsx
+++ b/src/ContactForm.jsx
@@ -9,7 +9,7 @@ const getServiceOptions = (t) => [
   { label: t('contact.services.other'), value: 'other' },
 ];
 
-export default function ContactForm() {
+export default function ContactForm({ title }) {
   const { t } = useTranslation();
   const [submitted, setSubmitted] = useState(false);
   const [form, setForm] = useState({
@@ -58,7 +58,7 @@ export default function ContactForm() {
       className="space-y-6 container-rounded bg-white/[0.06] backdrop-blur-md p-8 md:p-10 ring-1 ring-white/10 shadow-[inset_0_0_0_1px_rgba(182,146,255,.22),0_10px_28px_rgba(108,72,237,.18)]"
     >
       <h2 className="text-3xl font-bold text-white mb-6">
-        {t('contact.formTitle')}
+        {title || t('contact.formTitle')}
       </h2>
       <div>
         <span className="block mb-2 text-white">

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -102,6 +102,7 @@ export default function Header() {
                 openMenu={openMenu}
                 setOpenMenu={setOpenMenu}
                 dividerIndex={servicesItems.length}
+                dividerLabel={t('services.mobileAutomationTitle', 'Automatizaciones')}
               />
             </div>
           </div>
@@ -113,7 +114,7 @@ export default function Header() {
   );
 }
 
-function DropdownMenu({ id, title, items, openMenu, setOpenMenu, dividerIndex }) {
+function DropdownMenu({ id, title, items, openMenu, setOpenMenu, dividerIndex, dividerLabel }) {
   const menuRef = useRef(null);
   const closeTimer = useRef();
 
@@ -159,6 +160,7 @@ function DropdownMenu({ id, title, items, openMenu, setOpenMenu, dividerIndex })
             items={items}
             onSelect={() => setOpenMenu(null)}
             dividerIndex={dividerIndex}
+            dividerLabel={dividerLabel}
           />
         </div>
       )}

--- a/src/ServiciosPinnedSlider.jsx
+++ b/src/ServiciosPinnedSlider.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
+import ContactForm from './ContactForm';
 
 const PALETTE = {
   purpleDark: "#39166F",
@@ -103,22 +104,57 @@ export default function ServiciosPinnedSlider() {
     const wrapperHeight = vertical ? dims.vh * 0.8 : dims.vh;
 
   return (
-    <section
-      ref={sectionRef}
-      style={{ height: wrapperHeight, overflow: "hidden", background: `linear-gradient(120deg, ${PALETTE.blackPurple}, ${PALETTE.purpleDark})` }}
-    >
-      <div style={{ display: "flex", height: "100%", width: "100%" }}>
-        {items.map((it, j) => {
-            const w = Math.round(widths[j] || 0);
-            const thin = w <= THIN + 1;
-            return (
-              <div key={it.title} style={{ flex: `0 0 ${w}px`, height: "100%", position: "relative", overflow: "hidden", transition: "none", borderRight: j < renderIndex ? `1px solid rgba(172,172,172,.15)` : "none" }}>
-                <Panel item={it} thin={thin} palette={PALETTE} vertical={vertical} />
-              </div>
-            );
-        })}
-      </div>
-    </section>
+    <>
+      <section
+        ref={sectionRef}
+        style={{ height: wrapperHeight, overflow: "hidden", background: `linear-gradient(120deg, ${PALETTE.blackPurple}, ${PALETTE.purpleDark})` }}
+      >
+        <div style={{ display: "flex", height: "100%", width: "100%" }}>
+          {items.map((it, j) => {
+              const w = Math.round(widths[j] || 0);
+              const thin = w <= THIN + 1;
+              return (
+                <div key={it.title} style={{ flex: `0 0 ${w}px`, height: "100%", position: "relative", overflow: "hidden", transition: "none", borderRight: j < renderIndex ? `1px solid rgba(172,172,172,.15)` : "none" }}>
+                  <Panel item={it} thin={thin} palette={PALETTE} vertical={vertical} />
+                </div>
+              );
+          })}
+        </div>
+      </section>
+      {vertical && (
+        <section
+          className="px-6 py-12 space-y-8"
+          style={{ background: `linear-gradient(120deg, ${PALETTE.blackPurple}, ${PALETTE.purpleDark})`, color: PALETTE.grayLight }}
+        >
+          <div>
+            <h3 className="text-3xl font-bold mb-4">{t('services.mobileAutomationTitle', 'Automatizaciones')}</h3>
+            <ul className="list-disc pl-5 space-y-2 text-purple-200">
+              <li>
+                <Link to={t('routes.automation.appointments', '/services/genera-citas')} className="underline">
+                  {t('header.automationItems.appointments')}
+                </Link>
+              </li>
+              <li>
+                <Link to={t('routes.automation.inventory', '/services/inventario')} className="underline">
+                  {t('header.automationItems.inventory')}
+                </Link>
+              </li>
+              <li>
+                <Link to={t('routes.automation.quotes', '/services/cotizaciones')} className="underline">
+                  {t('header.automationItems.quotes')}
+                </Link>
+              </li>
+              <li>
+                <Link to={t('routes.automation.postSale', '/services/postventa')} className="underline">
+                  {t('header.automationItems.postSale')}
+                </Link>
+              </li>
+            </ul>
+          </div>
+          <ContactForm title={t('services.contactPrompt', '¿Buscas algo más? Contáctanos.')} />
+        </section>
+      )}
+    </>
   );
 }
 

--- a/src/TechMenu.jsx
+++ b/src/TechMenu.jsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 
 // Dropdown menu used in the header for Services and Automate sections.
 // It features a subtle purple gradient border and a dark glassy background.
-export default function TechMenu({ items, onSelect, className = "", dividerIndex }) {
+export default function TechMenu({ items, onSelect, className = "", dividerIndex, dividerLabel }) {
   return (
     <div
       className={`rounded-xl p-[1.5px] bg-gradient-to-r from-purple-600 to-purple-400 w-64 ${className}`}
@@ -13,6 +13,16 @@ export default function TechMenu({ items, onSelect, className = "", dividerIndex
       <div className="rounded-xl bg-black/80 backdrop-blur-sm py-2">
         {items.map((item, idx) => (
           <React.Fragment key={item.id}>
+            {dividerIndex === idx && (
+              <>
+                <div className="my-2 border-t border-white/10" />
+                {dividerLabel && (
+                  <div className="px-4 py-1 text-xs font-semibold text-white/60">
+                    {dividerLabel}
+                  </div>
+                )}
+              </>
+            )}
             <Link
               to={item.path}
               onClick={() => onSelect?.(item.id)}
@@ -22,9 +32,6 @@ export default function TechMenu({ items, onSelect, className = "", dividerIndex
             >
               {item.label}
             </Link>
-            {dividerIndex === idx + 1 && (
-              <div className="my-2 border-t border-white/10" />
-            )}
           </React.Fragment>
         ))}
       </div>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -49,7 +49,9 @@
     "title": "What do you gain with us?",
     "subtitle": "Digital Solutions for your business",
     "description": "We offer core services that cover all your business digital needs. Click on the cards to see more details.",
-    "sliderInstruction": "Move sideways to explore each panel"
+    "sliderInstruction": "Move sideways to explore each panel",
+    "mobileAutomationTitle": "Automations",
+    "contactPrompt": "Looking for something else? Contact us."
   },
   "about": {
     "title": "About Us",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -49,7 +49,9 @@
     "title": "¿Qué ganas con nosotros?",
     "subtitle": "Soluciones Digitales para tu empresa",
     "description": "Ofrecemos servicios principales que cubren todas las necesidades digitales de tu empresa. Haz clic en las tarjetas para ver más detalles.",
-    "sliderInstruction": "Mueve hacia los lados para explorar cada panel"
+    "sliderInstruction": "Mueve hacia los lados para explorar cada panel",
+    "mobileAutomationTitle": "Automatizaciones",
+    "contactPrompt": "¿Buscas algo más? Contáctanos."
   },
   "about": {
     "title": "Sobre Nosotros",


### PR DESCRIPTION
## Summary
- ensure services navigation shows automation group on mobile
- add automation hierarchy and contact form to mobile services page
- allow custom titles for contact form

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dc8f8e9548329bf7a065c875373ac