### PR TITLE
Default site language to English

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="es">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <!-- Use relative paths so assets resolve correctly on GitHub Pages -->

--- a/interactive-lens/index.html
+++ b/interactive-lens/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="es">
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -7,7 +7,7 @@ import en from './locales/en.json';
 const storedLang =
   typeof window !== 'undefined' && localStorage.getItem('language')
     ? localStorage.getItem('language')
-    : 'es';
+    : 'en';
 
 i18n.use(initReactI18next).init({
   resources: {
@@ -15,7 +15,7 @@ i18n.use(initReactI18next).init({
     en: { translation: en },
   },
   lng: storedLang,
-  fallbackLng: 'es',
+  fallbackLng: 'en',
   interpolation: {
     escapeValue: false,
   },

--- a/src/phone.html
+++ b/src/phone.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="es">
+<html lang="en">
 <head>
   <meta charset="utf-8" />
   <title>Phone 3D – vidrio + negro mate</title>


### PR DESCRIPTION
## Summary
- Change i18next default and fallback language to English
- Set HTML documents to use English as the default language

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689dca9ce6648329ae58ec2d67987ce7