### PR TITLE
Reduce landing margin on square viewports

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -243,7 +243,7 @@ function Landing() {
             initial={{ opacity: 0, y: 60 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.8 }}
-            className="font-lores text-5xl md:text-7xl text-[#D6D6D6] mb-10 md:mb-16 md:ml-[200px] leading-tight"
+            className="font-lores text-5xl md:text-7xl text-[#D6D6D6] mb-10 md:mb-16 md:ml-[200px] leading-tight square-ml-reduce"
           >
             <Trans i18nKey="hero.headline" components={{ 0: <span className="text-purple-300" /> }} />
           </motion.h1>
@@ -254,7 +254,7 @@ function Landing() {
                   el.scrollIntoView({ behavior: 'smooth' });
                 }
               }}
-              className="transition group absolute left-0 top-[110%] z-50 md:static md:mt-20 md:ml-[200px] flex h-14 w-48 md:h-20 md:w-64 items-center justify-center rounded-full bg-gradient-to-r from-purple-400 to-purple-700 p-[1.5px] text-white duration-300 hover:bg-gradient-to-l hover:shadow-2xl hover:shadow-purple-600/30"
+              className="transition group absolute left-0 top-[110%] z-50 md:static md:mt-20 md:ml-[200px] flex h-14 w-48 md:h-20 md:w-64 items-center justify-center rounded-full bg-gradient-to-r from-purple-400 to-purple-700 p-[1.5px] text-white duration-300 hover:bg-gradient-to-l hover:shadow-2xl hover:shadow-purple-600/30 square-ml-reduce"
             >
               <div className="flex h-full w-full items-center justify-center rounded-full bg-[#010207] transition duration-300 ease-in-out group-hover:bg-gradient-to-br group-hover:from-gray-700 group-hover:to-gray-900 font-argent">
                 {t("hero.cta", "Descúbrelo")}

--- a/src/index.css
+++ b/src/index.css
@@ -790,3 +790,9 @@ spline-viewer canvas#spline {
   .termhint-bubble { transition: none; }
   .termhint-link { transition: none; }
 }
+
+@media (min-width: 768px) and (min-aspect-ratio: 1/1) and (max-aspect-ratio: 1/1) {
+  .square-ml-reduce {
+    margin-left: 100px !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Reduce left margin of landing headline and CTA button on square screens to improve centering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e05bd60ac83299d5a6308d27afb1e