### PR TITLE
fix: enable navigation from service dropdown

### DIFF
--- a/src/TechMenu.jsx
+++ b/src/TechMenu.jsx
@@ -1,9 +1,11 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 // Dropdown menu used in the header for Services and Automate sections.
 // It features a subtle purple gradient border and a dark glassy background.
 export default function TechMenu({ items, onSelect, className = "", dividerIndex, dividerLabel }) {
+  const navigate = useNavigate();
+
   return (
     <div
       className={`rounded-xl p-[1.5px] bg-gradient-to-r from-purple-600 to-purple-400 w-64 ${className}`}
@@ -23,15 +25,18 @@ export default function TechMenu({ items, onSelect, className = "", dividerIndex
                 )}
               </>
             )}
-            <Link
-              to={item.path}
-              onClick={() => onSelect?.(item.id)}
-              className={`block px-4 py-2 ${
+            <button
+              type="button"
+              onClick={() => {
+                navigate(item.path);
+                onSelect?.(item.id);
+              }}
+              className={`block w-full text-left px-4 py-2 ${
                 idx === 0 ? "text-white" : "text-gray-300"
               } hover:bg-purple-500/20 transition rounded-md`}
             >
               {item.label}
-            </Link>
+            </button>
           </React.Fragment>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- ensure dropdown items use programmatic navigation so service pages open correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e4258161c8329856e5e665cbcb31a