### PR TITLE
fix: ensure service menu links navigate correctly

### DIFF
--- a/src/TechMenu.jsx
+++ b/src/TechMenu.jsx
@@ -1,11 +1,9 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 
 // Dropdown menu used in the header for Services and Automate sections.
 // It features a subtle purple gradient border and a dark glassy background.
 export default function TechMenu({ items, onSelect, className = "", dividerIndex, dividerLabel }) {
-  const navigate = useNavigate();
-
   return (
     <div
       className={`rounded-xl p-[1.5px] bg-gradient-to-r from-purple-600 to-purple-400 w-64 ${className}`}
@@ -25,18 +23,15 @@ export default function TechMenu({ items, onSelect, className = "", dividerIndex
                 )}
               </>
             )}
-            <button
-              type="button"
-              onClick={() => {
-                navigate(item.path);
-                onSelect?.(item.id);
-              }}
+            <Link
+              to={item.path}
+              onClick={() => onSelect?.(item.id)}
               className={`block w-full text-left px-4 py-2 ${
                 idx === 0 ? "text-white" : "text-gray-300"
               } hover:bg-purple-500/20 transition rounded-md`}
             >
               {item.label}
-            </button>
+            </Link>
           </React.Fragment>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- use `<Link>` components for header dropdown menu items

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e4b3180148329b89060f5a801096d