### PR TITLE
Fix static asset serving and deployment paths

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,6 +8,22 @@ const PORT = process.env.PORT || 3001;
 
 app.use(bodyParser.json());
 
+// Serve static assets from the project root and the public folder
+const rootDir = __dirname;
+const publicDir = path.join(rootDir, 'public');
+
+app.use(
+  express.static(rootDir, {
+    setHeaders(res, filePath) {
+      if (filePath.endsWith('.jsx')) {
+        // Ensure JSX files are served with a JavaScript MIME type
+        res.setHeader('Content-Type', 'application/javascript');
+      }
+    },
+  })
+);
+app.use(express.static(publicDir));
+
 const DB_FILE = path.join(__dirname, 'messages.json');
 function readDB() {
   try {
@@ -26,6 +42,11 @@ app.post('/api/messages', (req, res) => {
   db.push(newMsg);
   writeDB(db);
   res.json({ ok: true });
+});
+
+// Send index.html for any other request to support client-side routing
+app.get('*', (req, res) => {
+  res.sendFile(path.join(rootDir, 'index.html'));
 });
 
 app.listen(PORT, () => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
-  base: '/weavion/',
-}); 
+  // Serve assets from the root when deployed
+  base: '/',
+});


### PR DESCRIPTION
## Summary
- Serve project root and public assets in `server.js`
- Default Vite build `base` to root for correct asset paths

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e5bd41b2c83298ebaa1aa5ea90728