### PR TITLE
Serve local fonts and fix header logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,6 @@
     <!-- Load custom fonts -->
     <link rel="preconnect" href="https://fonts.cdnfonts.com" />
     <link href="https://fonts.cdnfonts.com/css/arial-nova" rel="stylesheet" />
-    <link href="https://fonts.cdnfonts.com/css/argent-pixel-cf" rel="stylesheet" />
 
     <!-- Preload Argent Pixel CF font files -->
     <link

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  command = "npm run build"
+  publish = "dist"

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ChevronDown } from 'lucide-react';
 import LanguageSelector from './LanguageSelector';
-import logo from './assets/weavionLogoBase64.js';
+import logo from './assets/logo.png';
 
 export default function Header() {
   const { t } = useTranslation();

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,5 @@
 @import url("https://use.typekit.net/dyf0yaq.css");
 @import url('https://fonts.cdnfonts.com/css/arial-nova');
-@import url('https://fonts.cdnfonts.com/css/argent-pixel-cf');
 @import url('https://use.typekit.net/dyf0yaq.css');
 
 /* Importación de la fuente Arial Nova con fallbacks locales */
@@ -59,15 +58,6 @@
   font-display: swap;
 }
 
-/*Lo-Res 21 OT serif Regular Font*/
-@font-face {
-  font-family: 'Lo-Res';
-  src: url('/fonts/lo-res.woff2') format('woff2'),
-  url('/fonts/lo-res.woff') format('woff');
-  font-weight: 400;
-  font-style: normal;
-  font-display: swap;
-}
 /* Preloading fonts for faster loading */
 head::before {
   content: '';
@@ -637,13 +627,6 @@ spline-viewer canvas#spline {
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-/* Tipografía Ars Pixel (ajusta ruta si la tienes en otra carpeta) */
-@font-face{
-  font-family:'Ars Pixel';
-  src:url('./assets/fonts/ArsPixel-Regular.woff2') format('woff2'),
-      url('./assets/fonts/ArsPixel-Regular.woff') format('woff');
-  font-weight:400;font-style:normal;font-display:swap;
-}
 
 :root{
   --text:#ECECEC;


### PR DESCRIPTION
## Summary
- load Argent Pixel CF from local files and drop failing CDN reference
- use local logo image in header instead of missing base64 module
- add Netlify build config and prune unused font-face rules

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e6187821083298f7b3de095c78bd9