### PR TITLE
fix: localize automation section routes

### DIFF
--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -15,10 +15,22 @@ export default function Header() {
   ];
 
   const automationItems = [
-    { label: t('header.automationItems.appointments', 'Genera citas'), path: '/services/genera-citas' },
-    { label: t('header.automationItems.inventory', 'Charla con tu inventario y modifícalo'), path: '/services/inventario' },
-    { label: t('header.automationItems.quotes', 'Entrega cotizaciones inmediatas'), path: '/services/cotizaciones' },
-    { label: t('header.automationItems.postSale', 'Postventa inteligente'), path: '/services/postventa' },
+    {
+      label: t('header.automationItems.appointments', 'Genera citas'),
+      path: t('routes.automation.appointments', '/services/genera-citas'),
+    },
+    {
+      label: t('header.automationItems.inventory', 'Charla con tu inventario y modifícalo'),
+      path: t('routes.automation.inventory', '/services/inventario'),
+    },
+    {
+      label: t('header.automationItems.quotes', 'Entrega cotizaciones inmediatas'),
+      path: t('routes.automation.quotes', '/services/cotizaciones'),
+    },
+    {
+      label: t('header.automationItems.postSale', 'Postventa inteligente'),
+      path: t('routes.automation.postSale', '/services/postventa'),
+    },
   ];
 
   return (


### PR DESCRIPTION
## Summary
- use translated routes for automation dropdown links so they switch languages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e66be972883298f25d34a530e374a