### PR TITLE
Remove Automations section and move contact form

### DIFF
--- a/src/ServiciosPinnedSlider.jsx
+++ b/src/ServiciosPinnedSlider.jsx
@@ -149,13 +149,11 @@ export default function ServiciosPinnedSlider() {
           })}
         </div>
       </section>
-      {vertical && (
-        <section
-          className="px-6 py-12 space-y-8"
-          style={{ background: `linear-gradient(120deg, ${PALETTE.blackPurple}, ${PALETTE.purpleDark})`, color: PALETTE.grayLight }}
-        >
-          <div>
-            <h3 className="text-3xl font-bold mb-4">{t('services.mobileAutomationTitle', 'Automatizaciones')}</h3>
+        {vertical && (
+          <section
+            className="px-6 py-12 space-y-8"
+            style={{ background: `linear-gradient(120deg, ${PALETTE.blackPurple}, ${PALETTE.purpleDark})`, color: PALETTE.grayLight }}
+          >
             <ul className="list-disc pl-5 space-y-2 text-purple-200">
               <li>
                 <Link to={t('routes.automation.appointments', '/services/genera-citas')} className="underline">
@@ -178,10 +176,9 @@ export default function ServiciosPinnedSlider() {
                 </Link>
               </li>
             </ul>
-          </div>
-          <ContactForm title={t('services.contactPrompt', '¿Buscas algo más? Contáctanos.')} />
-        </section>
-      )}
+            <ContactForm title={t('services.contactPrompt', '¿Buscas algo más? Contáctanos.')} />
+          </section>
+        )}
     </>
   );
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -50,8 +50,7 @@
     "subtitle": "Digital Solutions for your business",
     "description": "We offer core services that cover all your business digital needs. Click on the cards to see more details.",
     "sliderInstruction": "Move sideways to explore each panel",
-    "mobileAutomationTitle": "Automations",
-    "contactPrompt": "Looking for something else? Contact us."
+      "contactPrompt": "Looking for something else? Contact us."
   },
   "about": {
     "title": "About Us",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -50,8 +50,7 @@
     "subtitle": "Soluciones Digitales para tu empresa",
     "description": "Ofrecemos servicios principales que cubren todas las necesidades digitales de tu empresa. Haz clic en las tarjetas para ver más detalles.",
     "sliderInstruction": "Mueve hacia los lados para explorar cada panel",
-    "mobileAutomationTitle": "Automatizaciones",
-    "contactPrompt": "¿Buscas algo más? Contáctanos."
+      "contactPrompt": "¿Buscas algo más? Contáctanos."
   },
   "about": {
     "title": "Sobre Nosotros",


### PR DESCRIPTION
## Summary
- remove "Automatizaciones" heading and associated section
- show contact form beneath automation links for mobile
- drop unused translation key `mobileAutomationTitle`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e67388d48832994f1298d0b074226