### PR TITLE
Remove contact option from service and automation dropdowns

### DIFF
--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -87,14 +87,6 @@ function DropdownMenu({ title, items }) {
               {label}
             </Link>
           ))}
-
-          <Link
-            to="/contact"
-            onClick={() => setOpen(false)}
-            className="flex-1 text-center py-3 rounded-xl bg-purple-600 text-white hover:bg-purple-500 transition"
-          >
-            Contacto
-          </Link>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- remove contact link from services and automation dropdown menus

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e67c64ee8832987df58a165505196