### PR TITLE
feat: increase term hint bubble opacity

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -716,7 +716,7 @@ spline-viewer canvas#spline {
   transform: translateY(4px) scale(.98);
   transition: opacity .18s ease, transform .18s ease;
   /* efecto glass + metálico */
-  background: linear-gradient(180deg, rgba(255,255,255,.10), rgba(255,255,255,.04));
+  background: linear-gradient(180deg, rgba(255,255,255,.20), rgba(255,255,255,.08));
   border: 1px solid rgba(167,139,250,.35);
   box-shadow:
     0 8px 28px rgba(124,58,237,.22),


### PR DESCRIPTION
## Summary
- increase opacity of TermHint tooltip bubble for improved legibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e684e981c8329b961e072de05a139